### PR TITLE
Update library dependencies in agda2scala.cabal

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: [9.6.6, 9.8.2, 9.10.1]
+        ghc: [9.10.1] # [9.6.6, 9.8.2, 9.10.1]
     steps:
       - name: Checks-out repository
         uses: actions/checkout@v5

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -4,6 +4,9 @@ jobs:
   runhaskell:
     name: agda2scala
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: [9.6.6, 9.8.2, 9.10.1]
     steps:
       - name: Checks-out repository
         uses: actions/checkout@v5
@@ -12,8 +15,8 @@ jobs:
         uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: '9.8.1'
-          cabal-version: '3.10.1.0'
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: '3.10.3'
           cabal-update: true
 
       - name: Configure the build

--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -20,7 +20,7 @@ extra-doc-files:    README.md, CHANGELOG.md
 
 source-repository head
   type:     git
-  location: https://github.com/lemastero/agda2scala.git
+  location: https://github.com/dancewithheart/agda2scala.git
 
 common warnings
   ghc-options: -Wall
@@ -34,11 +34,11 @@ library
                        Agda.Compiler.Scala.PrintScala3
                        Paths_agda2scala
   autogen-modules:     Paths_agda2scala
-  build-depends:       base >= 4.13 && < 4.21,
-                       containers > 0.6 && < 0.8,
-                       Agda >= 2.7 && < 2.8,
-                       deepseq >= 1.4.4 && < 1.6,
-                       text >= 1.2.3.1
+  build-depends:       base       >= 4.13  && < 4.22,
+                       containers >  0.6   && < 0.9,
+                       Agda       >= 2.8.0 && < 2.9.0,
+                       deepseq    >= 1.4.4 && < 1.6,
+                       text       >= 2.0.2 && < 2.2
   default-language:    Haskell2010
   import:              warnings
 
@@ -47,8 +47,8 @@ executable agda2scala
   main-is:          Main.hs
   other-modules:    Paths_agda2scala
   autogen-modules:  Paths_agda2scala
-  build-depends:    base >= 4.13 && < 4.21,
-                    Agda >= 2.7 && < 2.8,
+  build-depends:    base   >= 4.13  && < 4.22,
+                    Agda   >= 2.8.0 && < 2.9.0,
                     agda2scala
   default-language: Haskell2010
   import:           warnings
@@ -59,7 +59,7 @@ test-suite agda2scala-test
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Main.hs
-  build-depends:    base >= 4.13 && < 4.21,
-                    Agda >= 2.7 && < 2.8,
-                    HUnit >= 1.6.2.0,
+  build-depends:    base   >= 4.13  && < 4.22,
+                    Agda   >= 2.8.0 && < 2.9.0,
+                    HUnit  >= 1.6.2.0,
                     agda2scala

--- a/src/Agda/Compiler/Scala/Backend.hs
+++ b/src/Agda/Compiler/Scala/Backend.hs
@@ -13,7 +13,7 @@ import Data.Maybe ( fromMaybe )
 import Data.Map ( Map )
 import qualified Data.Text as T
 import Data.Version ( showVersion )
-import System.Console.GetOpt ( OptDescr(Option), ArgDescr(ReqArg) )
+import Agda.Utils.GetOpt ( OptDescr(Option), ArgDescr(ReqArg) )
 
 import Paths_agda2scala ( version )
 
@@ -56,8 +56,10 @@ type ScalaDefinition = ScalaExpr
 {- Backend contains implementations of hooks called around compilation of Agda code -}
 scalaBackend' :: Backend' ScalaFlags ScalaEnv ScalaModuleEnv ScalaModule ScalaDefinition
 scalaBackend' = Backend'
-  { backendName           = "agda2scala"
+  { backendName           = T.pack "agda2scala"
   , backendVersion        = scalaBackendVersion
+  , backendInteractTop    = Nothing
+  , backendInteractHole   = Nothing
   , options               = defaultOptions
   , commandLineFlags      = scalaCmdLineFlags
   , isEnabled             = const True
@@ -70,8 +72,8 @@ scalaBackend' = Backend'
   , mayEraseType          = const $ return True
   }
 
-scalaBackendVersion :: Maybe String
-scalaBackendVersion = Just (showVersion version)
+scalaBackendVersion :: Maybe T.Text
+scalaBackendVersion = Just $ T.pack $ showVersion version
 
 defaultOptions :: ScalaFlags
 defaultOptions = Options{ optOutDir = Nothing, scalaDialect = Nothing }
@@ -101,7 +103,7 @@ scalaCompileDef :: ScalaEnv
   -> TCM ScalaDefinition
 scalaCompileDef _ _ isMain Defn{theDef = theDef, defName = defName}
   = withCurrentModule (qnameModule defName)
-  $ getUniqueCompilerPragma "AGDA2SCALA" defName >>= handlePragma defName theDef
+  $ getUniqueCompilerPragma (T.pack "AGDA2SCALA") defName >>= handlePragma defName theDef
   
 handlePragma :: QName -> Defn -> Maybe CompilerPragma -> TCMT IO ScalaDefinition
 handlePragma defName theDef pragma = case pragma of


### PR DESCRIPTION
* bild against matrix of `ghc` versions: `[9.6.6, 9.8.2, 9.10.1]`
* update dependencies:
```haskell
Agda           >= 2.8.0 && < 2.9.0
base            < 4.22
containers  < 0.9
text              >= 2.0.2 && < 2.2
```
* change Backend definition after updating to never Agda version