### PR TITLE
Polymorphic functions

### DIFF
--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -32,6 +32,8 @@ library
                        Agda.Compiler.Scala.ScalaExpr
                        Agda.Compiler.Scala.NameEnv
                        Agda.Compiler.Scala.AgdaToScalaExpr
+                       Agda.Compiler.Scala.AgdaToScalaExpr.Types
+                       Agda.Compiler.Scala.AgdaToScalaExpr.Terms
                        Agda.Compiler.Scala.PrintScala2
                        Agda.Compiler.Scala.PrintScala3
                        Paths_agda2scala

--- a/examples/adts.agda
+++ b/examples/adts.agda
@@ -63,3 +63,9 @@ withEscapes = "line1\nline2\t\"quote\"\\backslash"
 two : Nat
 two = 2
 -- TODO {-# COMPILE AGDA2SCALA two #-}
+
+-- polymorphic functions
+
+id : {A : Set} -> A -> A
+id x = x
+{-# COMPILE AGDA2SCALA id #-}

--- a/scala2/src/main/scala/examples/adts.scala
+++ b/scala2/src/main/scala/examples/adts.scala
@@ -36,4 +36,6 @@ def constRgbPair(rgbPairArg: RgbPair, rgbArg: Rgb): RgbPair = rgbPairArg
 def hello(): String = "Hello, world!"
 
 def withEscapes(): String = "line1\nline2\t\"quote\"\\backslash"
+
+def id[A](x1: A): A = x1
 }

--- a/scala3/src/main/scala/examples/adts.scala
+++ b/scala3/src/main/scala/examples/adts.scala
@@ -25,3 +25,5 @@ object adts:
   def hello(): String = "Hello, world!"
 
   def withEscapes(): String = "line1\nline2\t\"quote\"\\backslash"
+
+  def id[A](x1: A): A = x1

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr.hs
@@ -9,6 +9,8 @@ module Agda.Compiler.Scala.AgdaToScalaExpr
   , Env(..)
   ) where
 
+import Control.Monad (foldM)
+
 import Agda.Compiler.Backend (CompilerPragma, Defn(..), RecordData(..), funCompiled)
 import Agda.Compiler.Backend --TODO explicitly list dependencies
 import Agda.Syntax.Abstract.Name (QName)
@@ -39,6 +41,8 @@ import Agda.Compiler.Scala.AgdaToScalaExpr.Types
   , compileTypeTerm
   , binderName
   , fromQName
+  , pushTermBinder
+  , pushTyParam
   )
 
 import Agda.Compiler.Scala.AgdaToScalaExpr.Terms
@@ -112,11 +116,17 @@ compileCtor conQName = do
 ctorArgTypesFromType :: Type -> Either CompileError [ScalaType]
 ctorArgTypesFromType ty0 = do
   (pis, _res) <- unrollPi ty0
-  traverse (compileDomTypeWith emptyTyEnv)
-    [ dom
-    | (dom, _) <- pis
-    , getHiding dom /= Hidden
-    ]
+  (argTysRev, _env) <- foldM step ([], emptyTyEnv) (zip [0 :: Int ..] pis)
+  pure (reverse argTysRev)
+  where
+    step (acc, env) (i, (dom, _)) =
+      case getHiding dom of
+        Hidden -> do
+          let a = binderName i dom
+          pure (acc, pushTyParam a env)
+        _ -> do
+          ty <- compileDomTypeWith env dom
+          pure (ty : acc, pushTermBinder env)
 
 -- ===== Functions =============================================================
 

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr.hs
@@ -9,53 +9,44 @@ module Agda.Compiler.Scala.AgdaToScalaExpr
   , Env(..)
   ) where
 
-import qualified Data.Text as T
-
-import Agda.Compiler.Backend (CompilerPragma, Defn(..), RecordData(..), funCompiled, funClauses)
-import Agda.Compiler.Backend
+import Agda.Compiler.Backend (CompilerPragma, Defn(..), RecordData(..), funCompiled)
+import Agda.Compiler.Backend --TODO explicitly list dependencies
 import Agda.Syntax.Abstract.Name (QName)
-import Agda.Syntax.Common (Hiding(..), getHiding, Arg(..), NamedName, WithOrigin(..), Ranged(..))
-import Agda.Syntax.Common.Pretty (prettyShow)
-import Agda.Syntax.Internal
-  ( Abs
-  , ConHead(..)
-  , Dom(..)
-  , Dom'(..)
-  , Elim'(..)
-  , Term(..)
-  , Type
-  , Type''(..)
-  , Tele(..)
-  , Telescope
-  , qnameName
-  , unDom
-  )
-import Agda.Syntax.Literal (Literal(..))
+import Agda.Syntax.Common (Hiding(..), getHiding)
+import Agda.Syntax.Internal (Abs, Dom(..), Tele(..), Telescope, Type, Type''(..))
 import Agda.TypeChecking.Monad (TCM, getConstInfo)
 import Agda.TypeChecking.Monad.Base (Definition(..))
-import Agda.TypeChecking.CompiledClause (Case, CompiledClauses(..), CompiledClauses'(..))
+import Agda.TypeChecking.CompiledClause (CompiledClauses)
 import Agda.TypeChecking.Substitute (absBody)
 
-import Agda.Compiler.Scala.NameEnv (sanitizeScalaIdent)
 import Agda.Compiler.Scala.ScalaExpr
   ( ScalaCtor(..)
   , ScalaExpr(..)
   , ScalaName
-  , ScalaTerm(..)
   , ScalaType(..)
+  , ScalaTypeScheme(..)
+  , ScalaTerm(..)
   , SeVar(..)
-  , scalaTypeScheme
   )
 
--- ===== Errors ================================================================
+import Agda.Compiler.Scala.AgdaToScalaExpr.Types
+  ( CompileError(..)
+  , TyEnv(..)
+  , emptyTyEnv
+  , unrollPi
+  , funSchemeFromType
+  , compileDomTypeWith
+  , compileTypeTerm
+  , binderName
+  , fromQName
+  )
 
-data CompileError
-  = UnsupportedDefinition QName
-  | UnsupportedType Type
-  | UnsupportedTerm Term
-  | UnsupportedCompiledClauses
-  | VarOutOfRange Int Int
-  deriving (Eq, Show)
+import Agda.Compiler.Scala.AgdaToScalaExpr.Terms
+  ( Env(..)
+  , lookupVar
+  , compileBodyTerm
+  , compileFunctionBody
+  )
 
 -- ===== Entry point ===========================================================
 
@@ -65,7 +56,6 @@ data CompileError
 compileDefn :: Definition -> CompilerPragma -> TCM (Either CompileError ScalaExpr)
 compileDefn def _pragma = compileDefinition def
 
--- Keep compileDefn small: just dispatch.
 compileDefinition :: Definition -> TCM (Either CompileError ScalaExpr)
 compileDefinition = \case
   Defn{theDef = Datatype{dataCons = cons}, defName = qn} ->
@@ -91,7 +81,7 @@ compileRecord qn tel = do
   pure (SeProd (fromQName qn) vars)
   where
     compileField (i, dom) = do
-      ty <- compileDomType dom
+      ty <- compileDomTypeWith emptyTyEnv dom
       pure (SeVar (binderName i dom) ty)
 
 -- Agda.Syntax.Internal.Tele / Telescope:
@@ -119,22 +109,10 @@ compileCtor conQName = do
     argTys <- ctorArgTypesFromType conTy
     pure ScalaCtor { scName = fromQName conQName, scArgs = argTys }
 
--- | Split a type into Pi binders and a result type.
--- Stops at the first non-Pi.
-unrollPi :: Type -> Either CompileError ([(Dom Type, Abs Type)], Type)
-unrollPi = go []
-  where
-    go acc = \case
-      El _ (Pi dom absTy) ->
-        go ((dom, absTy) : acc) (absBody absTy)
-      ty ->
-        pure (reverse acc, ty)
-
--- | Extract explicit constructor argument types.
 ctorArgTypesFromType :: Type -> Either CompileError [ScalaType]
 ctorArgTypesFromType ty0 = do
   (pis, _res) <- unrollPi ty0
-  traverse compileDomType
+  traverse (compileDomTypeWith emptyTyEnv)
     [ dom
     | (dom, _) <- pis
     , getHiding dom /= Hidden
@@ -148,114 +126,8 @@ compileFunction
   -> Maybe CompiledClauses
   -> Either CompileError ScalaExpr
 compileFunction qn defTy mcc = do
-  (args, retTy) <- funArgsAndReturnFromType defTy
-  body          <- compileFunctionBody (argNames args) mcc
-  pure (SeFun (fromQName qn) args (scalaTypeScheme retTy) body)
-  where
-    argNames = map (\(SeVar n _) -> n)
-
-funArgsAndReturnFromType :: Type -> Either CompileError ([SeVar], ScalaType)
-funArgsAndReturnFromType ty0 = do
-  (pis, resTy) <- unrollPi ty0
-  args <- traverse mkArg (zip [0 :: Int ..] pis)
-  ret  <- compileType resTy
-  pure (concat args, ret)
-  where
-    mkArg (i, (dom, _absTy)) =
-      case getHiding dom of
-        Hidden -> pure []  -- drop implicit for now
-        _      -> do
-          ty <- compileDomType dom
-          pure [SeVar (binderName i dom) ty]
-
-compileFunctionBody :: [ScalaName] -> Maybe CompiledClauses -> Either CompileError ScalaTerm
-compileFunctionBody _ Nothing = Left UnsupportedCompiledClauses
-compileFunctionBody argNs (Just cc) =
-  case cc of
-    Case{}      -> Left UnsupportedCompiledClauses
-    Done _ term -> compileBodyTerm (envFromArgs argNs) term
-    _           -> Left UnsupportedCompiledClauses
-
--- ===== Terms ================================================================
-
-newtype Env = Env { unEnv :: [ScalaName] }
-  deriving (Eq, Show) -- env[0] = last binder
-
-envFromArgs :: [ScalaName] -> Env
-envFromArgs = Env . reverse
-
-lookupVar :: Env -> Int -> Either CompileError ScalaName
-lookupVar (Env xs) i =
-  case drop i xs of
-    v:_ -> Right v
-    []  -> Left (VarOutOfRange i (length xs))
-
-compileBodyTerm :: Env -> Term -> Either CompileError ScalaTerm
-compileBodyTerm env = \case
-  Var i _      -> STeVar <$> lookupVar env i
-  Def qn _     -> pure (STeVar (fromQName qn))
-  Con ch _ es  -> compileConApp env ch es
-  Lit lit      -> compileLiteral lit
-  t            -> Left (UnsupportedTerm t)
-
-compileConApp :: Env -> ConHead -> [Elim' Term] -> Either CompileError ScalaTerm
-compileConApp env conHead elims = do
-  args <- traverse (compileElim env) elims
-  let f = STeVar (fromQName (conName conHead))
-  pure $ case args of
-    [] -> f
-    _  -> STeApp f args
-
-compileElim :: Env -> Elim' Term -> Either CompileError ScalaTerm
-compileElim env = \case
-  Apply a -> compileBodyTerm env (unArg a)
-  _       -> Left (UnsupportedTerm (Var 0 [])) -- refine later (Proj/IApply)
-
-compileLiteral :: Literal -> Either CompileError ScalaTerm
-compileLiteral = \case
-  LitNat n    -> pure (STeLitInt (fromIntegral n))
-  LitWord64 n -> pure (STeLitInt (fromIntegral n))
-  LitString s -> pure (STeLitString (T.unpack s))
-  t           -> Left (UnsupportedTerm (Lit t)) -- for now
-
--- ===== Types ================================================================
-
--- Agda.Syntax.Internal.Dom:
--- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Internal.html#t:Dom
-compileDomType :: Dom Type -> Either CompileError ScalaType
-compileDomType = compileType . unDom
-
--- Agda.Syntax.Internal.Type:
--- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Internal.html#t:Type
-compileType :: Type -> Either CompileError ScalaType
-compileType = \case
-  El _ t -> compileTypeTerm t
-  t      -> Left (UnsupportedType t)
-
--- Agda.Syntax.Internal.Term:
--- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Internal.html#t:Term
-compileTypeTerm :: Term -> Either CompileError ScalaType
-compileTypeTerm = \case
-  Def qn _  -> Right (STyName (fromQName qn))
-  Var n _   -> Right (STyVar ("t" <> show n))
-  Con c _ _ -> Right (STyName (fromQName (conName c)))
-  Sort _    -> Right (STyName "Type")
-  t         -> Left (UnsupportedTerm t)
-
--- ===== Naming ===============================================================
-
-binderName :: Int -> Dom Type -> ScalaName
-binderName i dom =
-  case domName dom of
-    Just a  ->
-      let s = sanitizeScalaIdent (namedNameToStr a)
-      -- binder names should never be ""
-      in if null s then ("x" <> show i) else s
-    Nothing -> "x" <> show i
-
-namedNameToStr :: NamedName -> ScalaName
-namedNameToStr n = rangedThing (woThing n)
-
--- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Abstract-Name.html#t:QName
-fromQName :: QName -> ScalaName
-fromQName = prettyShow . qnameName
+  (args, scheme) <- funSchemeFromType defTy
+  body <- compileFunctionBody (argNames args) mcc
+  pure (SeFun (fromQName qn) args scheme body)
+    where
+      argNames = map (\(SeVar n _) -> n)

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Terms.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Terms.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Agda.Compiler.Scala.AgdaToScalaExpr.Terms
+  ( Env(..)
+  , envFromArgs
+  , lookupVar
+  , compileFunctionBody
+  , compileBodyTerm
+  ) where
+
+import qualified Data.Text as T
+
+import Agda.Syntax.Abstract.Name (QName)
+import Agda.Syntax.Internal (ConHead(..), Elim'(..), Term(..))
+import Agda.Syntax.Common (Arg(..))
+import Agda.Syntax.Literal (Literal(..))
+import Agda.TypeChecking.CompiledClause (Case, CompiledClauses(..), CompiledClauses'(..))
+
+import Agda.Compiler.Scala.ScalaExpr (ScalaName, ScalaTerm(..))
+import Agda.Compiler.Scala.AgdaToScalaExpr.Types (CompileError(..), fromQName)
+
+-- ===== Term variable environment ============================================
+
+-- | Term-variable environment for resolving de Bruijn Vars in *terms*.
+-- Convention: index 0 is the most recent binder.
+newtype Env = Env { unEnv :: [ScalaName] }
+  deriving (Eq, Show)
+
+-- Args come in source order; we want env[0] = last binder (de Bruijn 0).
+envFromArgs :: [ScalaName] -> Env
+envFromArgs = Env . reverse
+
+lookupVar :: Env -> Int -> Either CompileError ScalaName
+lookupVar (Env xs) i =
+  case drop i xs of
+    v:_ -> Right v
+    []  -> Left (VarOutOfRange i (length xs))
+
+-- ===== Function bodies =======================================================
+
+compileFunctionBody :: [ScalaName] -> Maybe CompiledClauses -> Either CompileError ScalaTerm
+compileFunctionBody _ Nothing   = Left UnsupportedCompiledClauses
+compileFunctionBody argNs (Just cc) =
+  case cc of
+    Case{}      -> Left UnsupportedCompiledClauses
+    Done _ term -> compileBodyTerm (envFromArgs argNs) term
+    _           -> Left UnsupportedCompiledClauses
+
+-- ===== Terms ================================================================
+
+compileBodyTerm :: Env -> Term -> Either CompileError ScalaTerm
+compileBodyTerm env = \case
+  Var i _      -> STeVar <$> lookupVar env i
+  Def qn _     -> pure (STeVar (fromQName qn))
+  Con ch _ es  -> compileConApp env ch es
+  Lit lit      -> compileLiteral lit
+  t            -> Left (UnsupportedTerm t)
+
+compileConApp :: Env -> ConHead -> [Elim' Term] -> Either CompileError ScalaTerm
+compileConApp env conHead elims = do
+  args <- traverse (compileElim env) elims
+  let f = STeVar (fromQName (conName conHead))
+  pure $ case args of
+    [] -> f
+    _  -> STeApp f args
+
+compileElim :: Env -> Elim' Term -> Either CompileError ScalaTerm
+compileElim env = \case
+  Apply a -> compileBodyTerm env (unArg a)
+  _       -> Left (UnsupportedTerm (Var 0 [])) -- refine later (Proj/IApply)
+
+compileLiteral :: Literal -> Either CompileError ScalaTerm
+compileLiteral = \case
+  LitNat n    -> pure (STeLitInt (fromIntegral n))
+  LitWord64 n -> pure (STeLitInt (fromIntegral n))
+  LitString s -> pure (STeLitString (T.unpack s))
+  l           -> Left (UnsupportedTerm (Lit l))

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -4,7 +4,6 @@ module Agda.Compiler.Scala.AgdaToScalaExpr.Types
   ( CompileError(..)
   , TyEnv(..)
   , emptyTyEnv
-  , extendTyEnv
   , lookupTyVar
   , unrollPi
   , isTypeParamBinder
@@ -17,9 +16,11 @@ module Agda.Compiler.Scala.AgdaToScalaExpr.Types
   , compileTypeTerm
   , binderName
   , fromQName
+  , pushTermBinder
+  , pushTyParam
   ) where
 
-import qualified Data.Text as T
+import Control.Monad (foldM)
 
 import Agda.Syntax.Abstract.Name (QName)
 import Agda.Syntax.Common (Hiding(..), getHiding, NamedName, WithOrigin(..), Ranged(..))
@@ -58,20 +59,28 @@ data CompileError
 
 -- | Type-variable environment for resolving de Bruijn Vars in *types*.
 -- Convention: index 0 is the most recently-bound type variable.
-newtype TyEnv = TyEnv { unTyEnv :: [ScalaName] }
+-- | Type-variable environment aligned with the full Pi telescope.
+-- Index 0 is the most recent binder. We store:
+--   Just "A"  for type parameters we want to name in Scala
+--   Nothing   for term binders (so indices line up)
+newtype TyEnv = TyEnv { unTyEnv :: [Maybe ScalaName] }
   deriving (Eq, Show)
 
 emptyTyEnv :: TyEnv
 emptyTyEnv = TyEnv []
 
-extendTyEnv :: ScalaName -> TyEnv -> TyEnv
-extendTyEnv a (TyEnv xs) = TyEnv (a : xs)
+pushTyParam :: ScalaName -> TyEnv -> TyEnv
+pushTyParam a (TyEnv xs) = TyEnv (Just a : xs)
+
+pushTermBinder :: TyEnv -> TyEnv
+pushTermBinder (TyEnv xs) = TyEnv (Nothing : xs)
 
 lookupTyVar :: TyEnv -> Int -> ScalaName
 lookupTyVar (TyEnv xs) i =
   case drop i xs of
-    v:_ -> v
-    []  -> "t" <> show i
+    (Just v : _) -> v
+    (Nothing : _) -> "t" <> show i    -- TODO dependent term binder; fallback for now
+    []            -> "t" <> show i
 
 -- ===== Pi traversal ==========================================================
 
@@ -129,7 +138,7 @@ collectTypeParams pis =
       if isTypeParamBinder dom
         then
           let nm = binderName i dom
-          in (ps <> [nm], extendTyEnv nm env)
+          in (ps <> [nm], pushTyParam nm env)
         else (ps, env)
 
 -- | Compute value arguments and polymorphic scheme from a function type.
@@ -137,19 +146,19 @@ collectTypeParams pis =
 funSchemeFromType :: Type -> Either CompileError ([SeVar], ScalaTypeScheme)
 funSchemeFromType ty0 = do
   (pis, resTy) <- unrollPi ty0
-  let (tyParams, tyEnv) = collectTypeParams pis
-
-  args <- fmap concat $ traverse (mkArg tyEnv) (zip [0 :: Int ..] pis)
-  ret  <- compileTypeWith tyEnv resTy
-
-  pure (args, ScalaTypeScheme { ssTyParams = tyParams, ssType = ret })
+  (args, tyParams, tyEnvFinal) <- foldM step ([], [], emptyTyEnv) (zip [0 :: Int ..] pis)
+  ret <- compileTypeWith tyEnvFinal resTy
+  pure (reverse args, ScalaTypeScheme { ssTyParams = reverse tyParams, ssType = ret })
   where
-    mkArg tyEnv (i, (dom, _absTy)) =
+    step (argsAcc, tpsAcc, env) (i, (dom, _absTy)) =
       case getHiding dom of
-        Hidden -> pure []  -- treated as type params
-        _      -> do
-          ty <- compileDomTypeWith tyEnv dom
-          pure [SeVar (binderName i dom) ty]
+        Hidden -> do
+          let a = binderName i dom
+          pure (argsAcc, a : tpsAcc, pushTyParam a env)
+        _ -> do
+          ty <- compileDomTypeWith env dom
+          let x = binderName i dom
+          pure (SeVar x ty : argsAcc, tpsAcc, pushTermBinder env)
 
 -- ===== Naming ================================================================
 

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -1,0 +1,171 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Agda.Compiler.Scala.AgdaToScalaExpr.Types
+  ( CompileError(..)
+  , TyEnv(..)
+  , emptyTyEnv
+  , extendTyEnv
+  , lookupTyVar
+  , unrollPi
+  , isTypeParamBinder
+  , collectTypeParams
+  , funSchemeFromType
+  , compileDomTypeWith
+  , compileTypeWith
+  , compileType
+  , compileTypeTermWith
+  , compileTypeTerm
+  , binderName
+  , fromQName
+  ) where
+
+import qualified Data.Text as T
+
+import Agda.Syntax.Abstract.Name (QName)
+import Agda.Syntax.Common (Hiding(..), getHiding, NamedName, WithOrigin(..), Ranged(..))
+import Agda.Syntax.Common.Pretty (prettyShow)
+import Agda.Syntax.Internal
+  ( Abs
+  , ConHead(..)
+  , Dom(..)
+  , Dom'(..)
+  , Term(..)
+  , Type
+  , Type''(..)
+  , qnameName
+  , unDom
+  )
+import Agda.TypeChecking.Substitute (absBody)
+
+import Agda.Compiler.Scala.NameEnv (sanitizeScalaIdent)
+import Agda.Compiler.Scala.ScalaExpr
+  ( ScalaName
+  , ScalaType(..)
+  , ScalaTypeScheme(..)
+  , SeVar(..)
+  )
+-- ===== Errors ================================================================
+
+data CompileError
+  = UnsupportedDefinition QName
+  | UnsupportedType Type
+  | UnsupportedTerm Term
+  | UnsupportedCompiledClauses
+  | VarOutOfRange Int Int
+  deriving (Eq, Show)
+
+-- ===== Type variable environment ============================================
+
+-- | Type-variable environment for resolving de Bruijn Vars in *types*.
+-- Convention: index 0 is the most recently-bound type variable.
+newtype TyEnv = TyEnv { unTyEnv :: [ScalaName] }
+  deriving (Eq, Show)
+
+emptyTyEnv :: TyEnv
+emptyTyEnv = TyEnv []
+
+extendTyEnv :: ScalaName -> TyEnv -> TyEnv
+extendTyEnv a (TyEnv xs) = TyEnv (a : xs)
+
+lookupTyVar :: TyEnv -> Int -> ScalaName
+lookupTyVar (TyEnv xs) i =
+  case drop i xs of
+    v:_ -> v
+    []  -> "t" <> show i
+
+-- ===== Pi traversal ==========================================================
+
+-- | Split a type into Pi binders and a result type. Stops at first non-Pi.
+unrollPi :: Type -> Either CompileError ([(Dom Type, Abs Type)], Type)
+unrollPi = go []
+  where
+    go acc = \case
+      El _ (Pi dom absTy) ->
+        go ((dom, absTy) : acc) (absBody absTy)
+      ty ->
+        pure (reverse acc, ty)
+
+-- ===== Type compilation ======================================================
+
+compileDomTypeWith :: TyEnv -> Dom Type -> Either CompileError ScalaType
+compileDomTypeWith tyEnv = compileTypeWith tyEnv . unDom
+
+compileTypeWith :: TyEnv -> Type -> Either CompileError ScalaType
+compileTypeWith tyEnv = \case
+  El _ t -> compileTypeTermWith tyEnv t
+  t      -> Left (UnsupportedType t)
+
+-- Agda.Syntax.Internal.Type:
+-- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Internal.html#t:Type
+compileType :: Type -> Either CompileError ScalaType
+compileType = compileTypeWith emptyTyEnv
+
+compileTypeTermWith :: TyEnv -> Term -> Either CompileError ScalaType
+compileTypeTermWith tyEnv = \case
+  Def qn _  -> Right (STyName (fromQName qn))
+  Var n _   -> Right (STyVar (lookupTyVar tyEnv n))
+  Con c _ _ -> Right (STyName (fromQName (conName c)))
+  Sort _    -> Right (STyName "Type")
+  t         -> Left (UnsupportedTerm t)
+
+-- Agda.Syntax.Internal.Term:
+-- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Internal.html#t:Term
+-- Backwards-compatible export: empty type-var env.
+compileTypeTerm :: Term -> Either CompileError ScalaType
+compileTypeTerm = compileTypeTermWith emptyTyEnv
+
+-- ===== Type scheme extraction ===============================================
+
+-- | Heuristic: treat all Hidden Pi binders as type parameters for now.
+-- Later refine (e.g. inspect dom type to distinguish implicit term args).
+isTypeParamBinder :: Dom Type -> Bool
+isTypeParamBinder dom = getHiding dom == Hidden
+
+collectTypeParams :: [(Dom Type, Abs Type)] -> ([ScalaName], TyEnv)
+collectTypeParams pis =
+  foldl step ([], emptyTyEnv) (zip [0 :: Int ..] pis)
+  where
+    step (ps, env) (i, (dom, _abs)) =
+      if isTypeParamBinder dom
+        then
+          let nm = binderName i dom
+          in (ps <> [nm], extendTyEnv nm env)
+        else (ps, env)
+
+-- | Compute value arguments and polymorphic scheme from a function type.
+-- Hidden Pis become `ssTyParams`; explicit Pis become `[SeVar]`.
+funSchemeFromType :: Type -> Either CompileError ([SeVar], ScalaTypeScheme)
+funSchemeFromType ty0 = do
+  (pis, resTy) <- unrollPi ty0
+  let (tyParams, tyEnv) = collectTypeParams pis
+
+  args <- fmap concat $ traverse (mkArg tyEnv) (zip [0 :: Int ..] pis)
+  ret  <- compileTypeWith tyEnv resTy
+
+  pure (args, ScalaTypeScheme { ssTyParams = tyParams, ssType = ret })
+  where
+    mkArg tyEnv (i, (dom, _absTy)) =
+      case getHiding dom of
+        Hidden -> pure []  -- treated as type params
+        _      -> do
+          ty <- compileDomTypeWith tyEnv dom
+          pure [SeVar (binderName i dom) ty]
+
+-- ===== Naming ================================================================
+
+-- Binder names should never be empty.
+binderName :: Int -> Dom Type -> ScalaName
+binderName i dom =
+  case domName dom of
+    Just a  ->
+      let s = sanitizeScalaIdent (namedNameToStr a)
+      in if null s then ("x" <> show i) else s
+    Nothing -> "x" <> show i
+
+namedNameToStr :: NamedName -> ScalaName
+namedNameToStr n = rangedThing (woThing n)
+
+-- QName -> ScalaName
+-- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Abstract-Name.html#t:QName
+fromQName :: QName -> ScalaName
+fromQName = prettyShow . qnameName

--- a/src/Agda/Compiler/Scala/PrintScala2.hs
+++ b/src/Agda/Compiler/Scala/PrintScala2.hs
@@ -33,9 +33,8 @@ printScala2 def = case def of
     printSealedTrait adtName <> nl <>
     printCompanionObject adtName (map (printCtor adtName) ctors) <>
     nl
-
   SeFun fName args resScheme body ->
-    "def" <> sp <> fName <>
+    "def" <> sp <> fName <> printTyParams (ssTyParams resScheme) <>
     "(" <> intercalate ", " (map printVar args) <> ")" <>
     ":" <> sp <> printType (ssType resScheme) <> sp <>
     "=" <> sp <> printTerm body <>
@@ -119,6 +118,10 @@ printType (STyApp n ts) =
   n <> "[" <> intercalate ", " (map printType ts) <> "]"
 printType (STyFun a b) =
   printType a <> " => " <> printType b
+
+printTyParams :: [ScalaName] -> String
+printTyParams [] = ""
+printTyParams ps = "[" <> intercalate ", " ps <> "]"
 
 -- ===== Vars / packages ======================================================
 

--- a/src/Agda/Compiler/Scala/PrintScala3.hs
+++ b/src/Agda/Compiler/Scala/PrintScala3.hs
@@ -26,10 +26,10 @@ printScala3 def = case def of
     <> bracketWithIndent (map printEnumCtor ctors) 2
     <> defsSeparator
   (SeFun fName args resType funBody) ->
-    "def" <> exprSeparator <> fName
+    "def" <> exprSeparator <> fName <> printTyParams (ssTyParams resType)
     <> "(" <> combineThem (map printVar args) <> ")"
-    <> ":" <> exprSeparator <> (printType (ssType resType)) <> exprSeparator
-    <> "=" <> exprSeparator <> (printTerm funBody)
+    <> ":" <> exprSeparator <> printType (ssType resType) <> exprSeparator
+    <> "=" <> exprSeparator <> printTerm funBody
     <> defsSeparator
   (SeProd name args) -> printCaseClass name args <> defsSeparator
   (SeUnhandled "" payload) -> ""
@@ -56,14 +56,38 @@ printType (STyVar v)     = v
 printType (STyApp n ts)  = n <> "[" <> intercalate ", " (map printType ts) <> "]"
 printType (STyFun a b)   = printType a <> " => " <> printType b
 
+printTyParams :: [ScalaName] -> String
+printTyParams [] = ""
+printTyParams ps = "[" <> intercalate ", " ps <> "]"
+
 printTerm :: ScalaTerm -> String
 printTerm (STeVar scalaName) = scalaName
-printTerm (STeApp st sts) = (printTerm st) <> "(" <> (show sts)  <> ")"
-printTerm (STeLam sns st) = (combineLines sns) <> " => " <> (printTerm st)
+printTerm (STeApp st sts) =
+  printTerm st <> "(" <> intercalate ", " (map printTerm sts) <> ")"
+printTerm (STeLam sns st) = "(" <> intercalate ", " sns <> ")" <> exprSeparator <> "=>" <> exprSeparator <> printTerm st
 printTerm (STeLitInt n) = show n
-printTerm (STeLitBool b) = show b
-printTerm (STeLitString s) = show s
-printTerm (STeError err) = "error " <> err
+printTerm (STeLitBool b) = if b then "true" else "false"
+printTerm (STeLitString s) = "\"" <> escapeScalaString s <> "\""
+printTerm (STeError err) = "sys.error(" <> "\"" <> escapeScalaString err <> "\"" <> ")"
+
+-- Escaping for Scala string literal content (no surrounding quotes).
+escapeScalaString :: String -> String
+escapeScalaString = concatMap $ \c -> case c of
+  '\\' -> "\\\\"
+  '\"' -> "\\\""
+  '\n' -> "\\n"
+  '\r' -> "\\r"
+  '\t' -> "\\t"
+  '\b' -> "\\b"
+  '\f' -> "\\f"
+  _ | c < ' '  -> unicodeEscape c
+    | otherwise -> [c]
+  where
+    unicodeEscape ch =
+      let n = fromEnum ch
+          hex = "0123456789abcdef"
+          h k = hex !! ((n `div` (16^k)) `mod` 16)
+      in ['\\','u', h 3, h 2, h 1, h 0]
 
 printVar :: SeVar -> String
 printVar (SeVar sName sType) = sName <> colonSeparator <> exprSeparator <> (printType sType)

--- a/test/PrintProps.hs
+++ b/test/PrintProps.hs
@@ -7,7 +7,6 @@
 -- This makes tests robust across refactors.
 module PrintProps (tests) where
 
-import Data.Char (isAlphaNum)
 import Data.List (isInfixOf)
 
 import Hedgehog (Group(..), Gen(..), Property, PropertyName(..), GroupName(..), property, forAll, assert, (===), success)
@@ -36,6 +35,7 @@ tests =
     , ("prop_scala3_stringEscapes_newline", prop_scala3_stringEscapes_newline)
     , ("prop_escape_no_raw_newlines", prop_escape_no_raw_newlines)
     , ("prop_printScala3_type_total", prop_printScala3_type_total)
+    , ("prop_scala2_prints_type_params_iff_present", prop_scala2_prints_type_params_iff_present)
     ]
 
 -- ===== Generators ============================================================
@@ -93,6 +93,12 @@ genScalaType =
     [ STyFun <$> genScalaType <*> genScalaType
     , STyApp <$> genTypeName <*> Gen.list (Range.linear 0 4) genScalaType
     ]
+
+genTyParam :: Gen String
+genTyParam = do
+  c <- Gen.upper
+  n <- Gen.int (Range.linear 0 10)
+  pure (c : show n)
 
 -- ===== Small AST builders ====================================================
 
@@ -160,3 +166,17 @@ prop_printScala3_type_total = property $ do
   -- should not throw (it’s pure, but total pattern match now)
   let _ = printType ty
   success
+
+prop_scala2_prints_type_params_iff_present :: Property
+prop_scala2_prints_type_params_iff_present = property $ do
+  ps <- forAll (Gen.list (Range.linear 0 4) genTyParam)
+
+  let scheme = ScalaTypeScheme ps (STyVar "A")
+      expr   = SeFun "f" [SeVar "x" (STyVar "A")] scheme (STeVar "x")
+      out    = printScala2 expr
+
+      hasBrackets = "[" `isInfixOf` out && "]" `isInfixOf` out
+
+  if null ps
+     then assert (not hasBrackets)
+     else assert hasBrackets

--- a/test/PrintScala2Test.hs
+++ b/test/PrintScala2Test.hs
@@ -11,6 +11,9 @@ import Agda.Compiler.Scala.PrintScala2
   )
 import Agda.Compiler.Scala.ScalaExpr
   ( ScalaExpr(..)
+  , ScalaType(..)
+  , ScalaTypeScheme(..)
+  , ScalaTerm(..)
   , ScalaCtor(..)
   , ScalaType(..)
   , SeVar(..)
@@ -100,6 +103,22 @@ testPrintScala2 = TestCase $
       "}\n" <>
       "}\n"
 
+testPolyDef :: Test
+testPolyDef = TestCase $
+  assertEqual "prints def with [A] and return A"
+    expected
+    (printScala2 expr)
+  where
+    expr =
+      SeFun
+        "id"
+        [SeVar "x1" (STyVar "A")]
+        (ScalaTypeScheme ["A"] (STyVar "A"))
+        (STeVar "x1")
+
+    expected =
+      "def id[A](x1: A): A = x1\n"
+
 printScala2Tests :: Test
 printScala2Tests = TestList
   [ TestLabel "printCaseObject" testPrintCaseObject
@@ -110,4 +129,5 @@ printScala2Tests = TestList
   , TestLabel "combineLines" testCombineLines
   , TestLabel "printCaseClass" testPrintCaseClass
   , TestLabel "printScala2" testPrintScala2
+  , TestLabel "printScala2 polymorphic def" testPolyDef
   ]


### PR DESCRIPTION
## Changes:
* Track type params for polymorphic functions
* make the type-variable environment (TyEnv) track all Π-binders (both implicit type params and explicit term params). Agda uses de Bruijn indices over the full binder stack that - Agda’s Var n in types refers to the n-th binder in the combined type+term binder stack. For {A : Set} -> A -> A, the return A often appears as Var 1, not Var 0, because the term binder sits at index 0. Without term binders in TyEnv, Var 1 couldn’t resolve to A.

AgdaToScalaExpr.Types:
* Redefined TyEnv as [Maybe ScalaName] to align with the full Π telescope:
Just "A" for type parameters
Nothing for term binders (keeps indices aligned)
*  Added pushTyParam, pushTermBinder, and updated lookupTyVar.
* Refactored funSchemeFromType to fold Π binders left-to-right, updating TyEnv incrementally and compiling types with the correct environment.
* updated constructor argument type extraction to use the same binder-aligned environment.

Fix #11 