### PR TITLE
Polymorphic ADTs - product types and sum types

### DIFF
--- a/examples/adts.agda
+++ b/examples/adts.agda
@@ -63,9 +63,20 @@ withEscapes = "line1\nline2\t\"quote\"\\backslash"
 two : Nat
 two = 2
 -- TODO {-# COMPILE AGDA2SCALA two #-}
+-- {-# COMPILE AGDA2SCALA_DEBUG Maybe #-}
 
 -- polymorphic functions
 
 id : {A : Set} -> A -> A
 id x = x
 {-# COMPILE AGDA2SCALA id #-}
+
+data Maybe (A : Set) : Set where
+  Just : (x : A) -> Maybe A
+  None :            Maybe A
+{-# COMPILE AGDA2SCALA Maybe #-}
+
+data List (X : Set) : Set where
+  Nil     : List X
+  Cons : X -> List X -> List X
+{-# COMPILE AGDA2SCALA List #-}

--- a/scala2/src/main/scala/examples/adts.scala
+++ b/scala2/src/main/scala/examples/adts.scala
@@ -38,4 +38,18 @@ def hello(): String = "Hello, world!"
 def withEscapes(): String = "line1\nline2\t\"quote\"\\backslash"
 
 def id[A](x1: A): A = x1
+
+sealed trait Maybe[A]
+object Maybe {
+  final case class Just[A](x0: A) extends Maybe[A]
+  case object None extends Maybe[Nothing]
+
+}
+
+sealed trait List[X]
+object List {
+  case object Nil extends List[Nothing]
+  final case class Cons[X](x0: X, x1: List[X]) extends List[X]
+
+}
 }

--- a/scala3/src/main/scala/examples/adts.scala
+++ b/scala3/src/main/scala/examples/adts.scala
@@ -27,3 +27,11 @@ object adts:
   def withEscapes(): String = "line1\nline2\t\"quote\"\\backslash"
 
   def id[A](x1: A): A = x1
+
+  enum Maybe[A]:
+    case Just[A](x0: A) extends Maybe[A]
+    case None extends Maybe[Nothing]
+
+  enum List[X]:
+    case Nil extends List[Nothing]
+    case Cons[X](x0: X, x1: List[X]) extends List[X]

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr.hs
@@ -13,7 +13,7 @@ import Control.Monad (foldM)
 
 import Agda.Compiler.Backend (CompilerPragma, Defn(..), RecordData(..), funCompiled)
 import Agda.Compiler.Backend --TODO explicitly list dependencies
-import Agda.Syntax.Abstract.Name (QName)
+import Agda.Syntax.Abstract.Name ()
 import Agda.Syntax.Common (Hiding(..), getHiding)
 import Agda.Syntax.Internal (Abs, Dom(..), Tele(..), Telescope, Type, Type''(..))
 import Agda.TypeChecking.Monad (TCM, getConstInfo)
@@ -26,14 +26,14 @@ import Agda.Compiler.Scala.ScalaExpr
   , ScalaExpr(..)
   , ScalaName
   , ScalaType(..)
-  , ScalaTypeScheme(..)
-  , ScalaTerm(..)
   , SeVar(..)
   )
 
 import Agda.Compiler.Scala.AgdaToScalaExpr.Types
   ( CompileError(..)
   , TyEnv(..)
+  , ctorArgTypesFromTypeWith
+  , dataTyParamsFromType
   , emptyTyEnv
   , unrollPi
   , funSchemeFromType
@@ -62,14 +62,14 @@ compileDefn def _pragma = compileDefinition def
 
 compileDefinition :: Definition -> TCM (Either CompileError ScalaExpr)
 compileDefinition = \case
-  Defn{theDef = Datatype{dataCons = cons}, defName = qn} ->
-    compileDataType qn cons
+  Defn{theDef = Datatype{dataCons = cons}, defName = qn, defType = ty} ->
+    compileDataType qn ty cons
 
   Defn{theDef = Function{funCompiled = cc}, defName = qn, defType = ty} ->
     pure (compileFunction qn ty cc)
 
-  Defn{theDef = RecordDefn (RecordData{_recTel = tel}), defName = qn} ->
-    pure (compileRecord qn tel)
+  Defn{theDef = RecordDefn (RecordData{_recTel = tel}), defName = qn, defType = ty} ->
+    pure (compileRecord qn ty tel)
 
   Defn{defName = qn} ->
     pure (Left (UnsupportedDefinition qn))
@@ -79,13 +79,15 @@ compileDefinition = \case
 -- | Compile a record telescope into a Scala case class.
 -- Agda.Syntax.Internal.Telescope (list-like):
 -- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Internal.html#t:Telescope
-compileRecord :: QName -> Telescope -> Either CompileError ScalaExpr
-compileRecord qn tel = do
-  vars <- traverse compileField (zip [0 :: Int ..] (teleToList tel))
-  pure (SeProd (fromQName qn) vars)
+compileRecord :: QName -> Type -> Telescope -> Either CompileError ScalaExpr
+compileRecord qn recTy tel = do
+  (tps, tyEnv) <- dataTyParamsFromType recTy
+  vars <- traverse (compileField tyEnv) (zip [0 :: Int ..] (teleToList tel))
+  pure (SeProd (fromQName qn) tps vars)
   where
-    compileField (i, dom) = do
-      ty <- compileDomTypeWith emptyTyEnv dom
+    compileField :: TyEnv -> (Int, Dom Type) -> Either CompileError SeVar
+    compileField tyEnv (i, dom) = do
+      ty <- compileDomTypeWith tyEnv dom
       pure (SeVar (binderName i dom) ty)
 
 -- Agda.Syntax.Internal.Tele / Telescope:
@@ -98,12 +100,27 @@ teleToList = \case
 
 -- ===== Datatypes / constructors =============================================
 
-compileDataType :: QName -> [QName] -> TCM (Either CompileError ScalaExpr)
-compileDataType typeName cons = do
-  eCtors <- traverse compileCtor cons
+compileDataType :: QName -> Type -> [QName] -> TCM (Either CompileError ScalaExpr)
+compileDataType typeName typeTy cons = do
+  let eParams = dataTyParamsFromType typeTy
+  eCtors <- traverse (compileCtorWith eParams) cons
   pure $ do
+    (tps, _tyEnv) <- eParams
     ctors <- sequence eCtors
-    pure (SeSum (fromQName typeName) ctors)
+    pure (SeSum (fromQName typeName) tps ctors)
+
+-- Compile constructors using the datatype TyEnv
+compileCtorWith
+  :: Either CompileError ([ScalaName], TyEnv)
+  -> QName
+  -> TCM (Either CompileError ScalaCtor)
+compileCtorWith eParams conQName = do
+  conDef <- getConstInfo conQName
+  let conTy = defType conDef
+  pure $ do
+    (_tps, tyEnv) <- eParams
+    argTys <- ctorArgTypesFromTypeWith tyEnv conTy
+    pure ScalaCtor { scName = fromQName conQName, scArgs = argTys }
 
 compileCtor :: QName -> TCM (Either CompileError ScalaCtor)
 compileCtor conQName = do

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr.hs
@@ -33,6 +33,7 @@ import Agda.Compiler.Scala.AgdaToScalaExpr.Types
   ( CompileError(..)
   , TyEnv(..)
   , ctorArgTypesFromTypeWith
+  , ctorArgTypesFromType
   , dataTyParamsFromType
   , emptyTyEnv
   , unrollPi
@@ -129,21 +130,6 @@ compileCtor conQName = do
   pure $ do
     argTys <- ctorArgTypesFromType conTy
     pure ScalaCtor { scName = fromQName conQName, scArgs = argTys }
-
-ctorArgTypesFromType :: Type -> Either CompileError [ScalaType]
-ctorArgTypesFromType ty0 = do
-  (pis, _res) <- unrollPi ty0
-  (argTysRev, _env) <- foldM step ([], emptyTyEnv) (zip [0 :: Int ..] pis)
-  pure (reverse argTysRev)
-  where
-    step (acc, env) (i, (dom, _)) =
-      case getHiding dom of
-        Hidden -> do
-          let a = binderName i dom
-          pure (acc, pushTyParam a env)
-        _ -> do
-          ty <- compileDomTypeWith env dom
-          pure (ty : acc, pushTermBinder env)
 
 -- ===== Functions =============================================================
 

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Terms.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Terms.hs
@@ -9,12 +9,10 @@ module Agda.Compiler.Scala.AgdaToScalaExpr.Terms
   ) where
 
 import qualified Data.Text as T
-
-import Agda.Syntax.Abstract.Name (QName)
 import Agda.Syntax.Internal (ConHead(..), Elim'(..), Term(..))
 import Agda.Syntax.Common (Arg(..))
 import Agda.Syntax.Literal (Literal(..))
-import Agda.TypeChecking.CompiledClause (Case, CompiledClauses(..), CompiledClauses'(..))
+import Agda.TypeChecking.CompiledClause (CompiledClauses, CompiledClauses'(..))
 
 import Agda.Compiler.Scala.ScalaExpr (ScalaName, ScalaTerm(..))
 import Agda.Compiler.Scala.AgdaToScalaExpr.Types (CompileError(..), fromQName)

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -163,8 +163,9 @@ compileTypeArgs tyEnv elims =
 compileTypeTerm :: Term -> Either CompileError ScalaType
 compileTypeTerm = compileTypeTermWith emptyTyEnv
 
--- compile each dom - fold binders and update TyEnv
--- fter each explicit argument, do pushTermBinder env so later references to A resolve correctly
+-- We fold Π binders left-to-right.
+-- After each explicit binder we pushTermBinder to keep de Bruijn indices aligned.
+-- Otherwise later args that reference earlier type params (e.g. xs : List A) will become tN.
 ctorArgTypesFromTypeWith :: TyEnv -> Type -> Either CompileError [ScalaType]
 ctorArgTypesFromTypeWith env0 ty0 = do
   (pis, _res) <- unrollPi ty0

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -23,13 +23,14 @@ module Agda.Compiler.Scala.AgdaToScalaExpr.Types
 import Control.Monad (foldM)
 
 import Agda.Syntax.Abstract.Name (QName)
-import Agda.Syntax.Common (Hiding(..), getHiding, NamedName, WithOrigin(..), Ranged(..))
+import Agda.Syntax.Common (Arg(..), Hiding(..), getHiding, NamedName, WithOrigin(..), Ranged(..))
 import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Internal
   ( Abs
   , ConHead(..)
   , Dom
   , Dom'(..)
+  , Elim'(..)
   , Term(..)
   , Type
   , Type''(..)
@@ -111,11 +112,30 @@ compileType = compileTypeWith emptyTyEnv
 
 compileTypeTermWith :: TyEnv -> Term -> Either CompileError ScalaType
 compileTypeTermWith tyEnv = \case
-  Def qn _  -> Right (STyName (fromQName qn))
-  Var n _   -> Right (STyVar (lookupTyVar tyEnv n))
+  Def qn elims -> do
+    args <- compileTypeArgs tyEnv elims
+    let f = fromQName qn
+    pure $ case args of
+      [] -> STyName f
+      _  -> STyApp f args
+
+  Var n elims -> do
+    args <- compileTypeArgs tyEnv elims
+    let f = lookupTyVar tyEnv n
+    pure $ case args of
+      [] -> STyVar f
+      _  -> STyApp f args
+
   Con c _ _ -> Right (STyName (fromQName (conName c)))
   Sort _    -> Right (STyName "Type")
   t         -> Left (UnsupportedTerm t)
+
+compileTypeArgs :: TyEnv -> [Elim' Term] -> Either CompileError [ScalaType]
+compileTypeArgs tyEnv elims =
+  traverse fromApply [ a | Apply a <- elims ]
+  where
+    fromApply :: Arg Term -> Either CompileError ScalaType
+    fromApply a = compileTypeTermWith tyEnv (unArg a)
 
 -- Agda.Syntax.Internal.Term:
 -- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Internal.html#t:Term

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -8,6 +8,8 @@ module Agda.Compiler.Scala.AgdaToScalaExpr.Types
   , unrollPi
   , isTypeParamBinder
   , collectTypeParams
+  , ctorArgTypesFromTypeWith
+  , dataTyParamsFromType
   , funSchemeFromType
   , compileDomTypeWith
   , compileTypeWith
@@ -130,6 +132,24 @@ compileTypeTermWith tyEnv = \case
   Sort _    -> Right (STyName "Type")
   t         -> Left (UnsupportedTerm t)
 
+-- | Extract type parameters from a data/record type signature.
+-- We treat only binders whose dom type is type-like (Sort/Pi..Sort) as type params.
+-- Example: Maybe (A : Type u) : Type u   -- A is NotHidden but type-like
+dataTyParamsFromType :: Type -> Either CompileError ([ScalaName], TyEnv)
+dataTyParamsFromType ty0 = do
+  (pis, _res) <- unrollPi ty0
+  -- fold like funSchemeFromType but without term args; for datatypes
+  foldM step ([], emptyTyEnv) (zip [0 :: Int ..] pis)
+  where
+    step (ps, env) (i, (dom, _absTy)) =
+      if isDataTypeParamBinder dom
+        then
+          let a = binderName i dom
+          in pure (ps <> [a], pushTyParam a env)
+        else
+          -- datatype indices/term params are possible; keep env aligned
+          pure (ps, pushTermBinder env)
+
 compileTypeArgs :: TyEnv -> [Elim' Term] -> Either CompileError [ScalaType]
 compileTypeArgs tyEnv elims =
   traverse fromApply [ a | Apply a <- elims ]
@@ -143,10 +163,50 @@ compileTypeArgs tyEnv elims =
 compileTypeTerm :: Term -> Either CompileError ScalaType
 compileTypeTerm = compileTypeTermWith emptyTyEnv
 
+ctorArgTypesFromTypeWith :: TyEnv -> Type -> Either CompileError [ScalaType]
+ctorArgTypesFromTypeWith env ty0 = do
+  (pis, _res) <- unrollPi ty0
+  foldM step [] (zip [0 :: Int ..] pis)
+  where
+    step acc (i, (dom, _absTy)) =
+      case getHiding dom of
+        Hidden ->
+          if isTypeParamBinder dom
+            then pure acc -- ctor-level implicit type param; ignore for now
+            else pure acc -- implicit term; ignore for now
+        _ -> do
+          ty <- compileDomTypeWith env dom
+          pure (acc <> [ty])
+
 -- ===== Type scheme extraction ===============================================
 
+-- | Classification of Π-binders into Scala type parameters vs term parameters.
+--
+-- Agda represents both implicit and explicit binders as Π (Pi) in 'defType'.
+-- A binder's *hiding* (Hidden/NotHidden) is not enough to decide whether it is a
+-- type parameter:
+--
+--   • Datatypes/records commonly have *explicit* type parameters:
+--       data Maybe (A : Type u) : Type u
+--     so we should treat type-like binders as type params regardless of hiding.
+--
+--   • Functions often have implicit type parameters and explicit term parameters:
+--       id : {A : Type u} -> A -> A
+--     Here we usually want only *Hidden + type-like* binders as Scala type params,
+--     to avoid turning explicit term arguments into type params.
+--
+-- The helpers below encode this policy in one place.
 isTypeParamBinder :: Dom Type -> Bool
 isTypeParamBinder dom = getHiding dom == Hidden && isTypeLike (unDom dom)
+
+-- | Datatypes/records: treat any type-like binder as a Scala type parameter.
+isDataTypeParamBinder :: Dom Type -> Bool
+isDataTypeParamBinder dom = isTypeLike (unDom dom)
+
+-- | Functions: default policy is "Hidden + type-like" is a Scala type parameter.
+-- (We still track other binders in TyEnv to keep de Bruijn indices aligned.)
+isFunTypeParamBinder :: Dom Type -> Bool
+isFunTypeParamBinder dom = getHiding dom == Hidden && isTypeLike (unDom dom)
 
 -- | True if the binder's type is a universe (Type/Set) or a type constructor ending in a universe.
 -- This lets us distinguish implicit *type parameters* from implicit *term arguments*.
@@ -179,23 +239,17 @@ collectTypeParams pis =
 funSchemeFromType :: Type -> Either CompileError ([SeVar], ScalaTypeScheme)
 funSchemeFromType ty0 = do
   (pis, resTy) <- unrollPi ty0
-  (args, tyParams, tyEnvFinal) <- foldM step ([], [], emptyTyEnv) (zip [0 :: Int ..] pis)
-  ret <- compileTypeWith tyEnvFinal resTy
-  pure (reverse args, ScalaTypeScheme { ssTyParams = reverse tyParams, ssType = ret })
+  (args, tps, env) <- foldM step ([], [], emptyTyEnv) (zip [0 :: Int ..] pis)
+  ret <- compileTypeWith env resTy
+  pure (reverse args, ScalaTypeScheme (reverse tps) ret)
   where
-    step (argsAcc, tpsAcc, env) (i, (dom, _absTy)) =
+    step (argsAcc, tpsAcc, env) (i, (dom, _)) =
       case getHiding dom of
-        Hidden
-          | isTypeParamBinder dom ->
-              let a = binderName i dom
-              in pure (argsAcc, a : tpsAcc, pushTyParam a env)
+        Hidden | isFunTypeParamBinder dom ->
+          let a = binderName i dom
+          in pure (argsAcc, a : tpsAcc, pushTyParam a env)
 
-          | otherwise -> do
-              -- implicit term binder: still shifts indices!
-              ty <- compileDomTypeWith env dom
-              let x = binderName i dom
-              pure (SeVar x ty : argsAcc, tpsAcc, pushTermBinder env)
-
+        -- Any other binder is a term binder (explicit or implicit):
         _ -> do
           ty <- compileDomTypeWith env dom
           let x = binderName i dom

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -119,6 +119,9 @@ compileTypeWith tyEnv = \case
 compileType :: Type -> Either CompileError ScalaType
 compileType = compileTypeWith emptyTyEnv
 
+-- Agda represents type application via eliminations (elims) on Def/Var.
+-- Example: List A appears as Def List [Apply A].
+-- We translate Apply args into STyApp/List[A].
 compileTypeTermWith :: TyEnv -> Term -> Either CompileError ScalaType
 compileTypeTermWith tyEnv = \case
   Def qn elims -> do

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -28,7 +28,7 @@ import Agda.Syntax.Common.Pretty (prettyShow)
 import Agda.Syntax.Internal
   ( Abs
   , ConHead(..)
-  , Dom(..)
+  , Dom
   , Dom'(..)
   , Term(..)
   , Type
@@ -125,10 +125,23 @@ compileTypeTerm = compileTypeTermWith emptyTyEnv
 
 -- ===== Type scheme extraction ===============================================
 
--- | Heuristic: treat all Hidden Pi binders as type parameters for now.
--- Later refine (e.g. inspect dom type to distinguish implicit term args).
 isTypeParamBinder :: Dom Type -> Bool
-isTypeParamBinder dom = getHiding dom == Hidden
+isTypeParamBinder dom = getHiding dom == Hidden && isTypeLike (unDom dom)
+
+-- | True if the binder's type is a universe (Type/Set) or a type constructor ending in a universe.
+-- This lets us distinguish implicit *type parameters* from implicit *term arguments*.
+--
+-- In Agda internal syntax, "A : Type u" appears as El _ (Sort _).
+-- A higher-kinded parameter like "F : Type u -> Type u" appears as El _ (Pi _ -> Sort _).
+isTypeLike :: Type -> Bool
+isTypeLike = \case
+  El _ t -> goTerm t
+  _      -> False
+  where
+    goTerm = \case
+      Sort _     -> True
+      Pi _ absTy -> isTypeLike (absBody absTy)
+      _          -> False
 
 collectTypeParams :: [(Dom Type, Abs Type)] -> ([ScalaName], TyEnv)
 collectTypeParams pis =

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -9,6 +9,7 @@ module Agda.Compiler.Scala.AgdaToScalaExpr.Types
   , isTypeParamBinder
   , collectTypeParams
   , ctorArgTypesFromTypeWith
+  , ctorArgTypesFromType
   , dataTyParamsFromType
   , funSchemeFromType
   , compileDomTypeWith
@@ -184,6 +185,9 @@ ctorArgTypesFromTypeWith env0 ty0 = do
         _ -> do
           ty <- compileDomTypeWith env dom
           pure (ty : acc, pushTermBinder env)
+
+ctorArgTypesFromType :: Type -> Either CompileError [ScalaType]
+ctorArgTypesFromType = ctorArgTypesFromTypeWith emptyTyEnv
 
 -- ===== Type scheme extraction ===============================================
 

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -7,7 +7,6 @@ module Agda.Compiler.Scala.AgdaToScalaExpr.Types
   , lookupTyVar
   , unrollPi
   , isTypeParamBinder
-  , collectTypeParams
   , ctorArgTypesFromTypeWith
   , ctorArgTypesFromType
   , dataTyParamsFromType
@@ -233,17 +232,6 @@ isTypeLike = \case
       Sort _     -> True
       Pi _ absTy -> isTypeLike (absBody absTy)
       _          -> False
-
-collectTypeParams :: [(Dom Type, Abs Type)] -> ([ScalaName], TyEnv)
-collectTypeParams pis =
-  foldl step ([], emptyTyEnv) (zip [0 :: Int ..] pis)
-  where
-    step (ps, env) (i, (dom, _abs)) =
-      if isTypeParamBinder dom
-        then
-          let nm = binderName i dom
-          in (ps <> [nm], pushTyParam nm env)
-        else (ps, env)
 
 -- | Compute value arguments and polymorphic scheme from a function type.
 -- Hidden Pis become `ssTyParams`; explicit Pis become `[SeVar]`.

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -173,9 +173,12 @@ compileTypeArgs tyEnv elims =
 compileTypeTerm :: Term -> Either CompileError ScalaType
 compileTypeTerm = compileTypeTermWith emptyTyEnv
 
--- We fold Π binders left-to-right.
--- After each explicit binder we pushTermBinder to keep de Bruijn indices aligned.
--- Otherwise later args that reference earlier type params (e.g. xs : List A) will become tN.
+-- Constructor types are Π-chains. We fold Π binders left-to-right.
+-- Later argument types may reference earlier binders.
+-- We must pushTermBinder after each explicit argument to keep the TyEnv aligned.
+-- This fixes cases like:
+--   Cons : A -> List A -> List A
+-- where the second arg 'List A' refers to A with a shifted de Bruijn index.
 ctorArgTypesFromTypeWith :: TyEnv -> Type -> Either CompileError [ScalaType]
 ctorArgTypesFromTypeWith env0 ty0 = do
   (pis, _res) <- unrollPi ty0

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -163,20 +163,27 @@ compileTypeArgs tyEnv elims =
 compileTypeTerm :: Term -> Either CompileError ScalaType
 compileTypeTerm = compileTypeTermWith emptyTyEnv
 
+-- compile each dom - fold binders and update TyEnv
+-- fter each explicit argument, do pushTermBinder env so later references to A resolve correctly
 ctorArgTypesFromTypeWith :: TyEnv -> Type -> Either CompileError [ScalaType]
-ctorArgTypesFromTypeWith env ty0 = do
+ctorArgTypesFromTypeWith env0 ty0 = do
   (pis, _res) <- unrollPi ty0
-  foldM step [] (zip [0 :: Int ..] pis)
+  (argTysRev, _envFinal) <- foldM step ([], env0) (zip [0 :: Int ..] pis)
+  pure (reverse argTysRev)
   where
-    step acc (i, (dom, _absTy)) =
+    step (acc, env) (i, (dom, _absTy)) =
       case getHiding dom of
         Hidden ->
-          if isTypeParamBinder dom
-            then pure acc -- ctor-level implicit type param; ignore for now
-            else pure acc -- implicit term; ignore for now
+          -- ctor-level implicit binders: keep TyEnv aligned, but don't emit args
+          if isDataTypeParamBinder dom
+            then
+              let a = binderName i dom
+              in pure (acc, pushTyParam a env)
+            else
+              pure (acc, pushTermBinder env)
         _ -> do
           ty <- compileDomTypeWith env dom
-          pure (acc <> [ty])
+          pure (ty : acc, pushTermBinder env)
 
 -- ===== Type scheme extraction ===============================================
 

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -185,9 +185,17 @@ funSchemeFromType ty0 = do
   where
     step (argsAcc, tpsAcc, env) (i, (dom, _absTy)) =
       case getHiding dom of
-        Hidden -> do
-          let a = binderName i dom
-          pure (argsAcc, a : tpsAcc, pushTyParam a env)
+        Hidden
+          | isTypeParamBinder dom ->
+              let a = binderName i dom
+              in pure (argsAcc, a : tpsAcc, pushTyParam a env)
+
+          | otherwise -> do
+              -- implicit term binder: still shifts indices!
+              ty <- compileDomTypeWith env dom
+              let x = binderName i dom
+              pure (SeVar x ty : argsAcc, tpsAcc, pushTermBinder env)
+
         _ -> do
           ty <- compileDomTypeWith env dom
           let x = binderName i dom

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Types.hs
@@ -60,12 +60,19 @@ data CompileError
 
 -- ===== Type variable environment ============================================
 
--- | Type-variable environment for resolving de Bruijn Vars in *types*.
--- Convention: index 0 is the most recently-bound type variable.
--- | Type-variable environment aligned with the full Pi telescope.
--- Index 0 is the most recent binder. We store:
---   Just "A"  for type parameters we want to name in Scala
---   Nothing   for term binders (so indices line up)
+-- | TyEnv is aligned with the full Π telescope of a 'Type'.
+--
+-- Agda uses de Bruijn indices across *all* binders (type params and term params).
+-- For example:
+--
+--   id : {A : Type u} -> A -> A
+--
+-- The result 'A' is often Var 1 (because the term binder sits at index 0).
+-- To resolve Vars correctly, TyEnv stores:
+--   Just "A"  for type parameters we want to surface in Scala
+--   Nothing   for term binders (to keep indices aligned)
+--
+-- Index 0 is the most recent binder.
 newtype TyEnv = TyEnv { unTyEnv :: [Maybe ScalaName] }
   deriving (Eq, Show)
 

--- a/src/Agda/Compiler/Scala/Backend.hs
+++ b/src/Agda/Compiler/Scala/Backend.hs
@@ -19,15 +19,15 @@ import Data.Maybe ( fromMaybe )
 import Data.Map ( Map )
 import qualified Data.Text as T
 import Data.Version ( showVersion )
-import Data.IORef (IORef, newIORef, readIORef)
+import Data.IORef (IORef, newIORef, readIORef, atomicModifyIORef')
 
 import Paths_agda2scala ( version )
 
 import Agda.Utils.GetOpt ( OptDescr(Option), ArgDescr(ReqArg) )
 import Agda.Main ( runAgda )
 import Agda.Compiler.Backend
-  ( Backend(..)
-  , Backend'(..)
+  ( Backend
+  , Backend'
   , Recompile(..)
   , IsMain
   , Flag
@@ -52,22 +52,16 @@ import Agda.Compiler.Backend
   , mayEraseType
   )
 import Agda.Compiler.Backend -- otherwise GHC complains about Backend and Backend'
-import Agda.Interaction.Options ( OptDescr )
-import Agda.Compiler.Common ( curIF, compileDir )
-import Agda.Syntax.Abstract.Name ( QName )
+import Agda.Compiler.Common ( compileDir )
 import Agda.Syntax.Common ( moduleNameParts )
-import Agda.Syntax.Internal ( qnameModule )
-import Agda.Syntax.TopLevelModuleName ( TopLevelModuleName, moduleNameToFileName )
+import Agda.Syntax.TopLevelModuleName ( moduleNameToFileName )
 
-import Agda.Compiler.Scala.ScalaExpr ( ScalaName, ScalaTypeScheme, ScalaExpr(..), unHandled )
+import Agda.Compiler.Scala.ScalaExpr (ScalaExpr(..), ScalaTerm(..), unHandled )
 import Agda.Compiler.Scala.AgdaToScalaExpr ( CompileError, compileDefn )
 import Agda.Compiler.Scala.PrintScala2 ( printScala2 )
 import Agda.Compiler.Scala.PrintScala3 ( printScala3 )
-import Agda.Compiler.Scala.NameEnv (NameEnv, emptyNameEnv)
+import Agda.Compiler.Scala.NameEnv (NameEnv, emptyNameEnv, registerCtors, lookupCtorOwner)
 
-import Data.IORef (atomicModifyIORef', readIORef)
-import Agda.Compiler.Scala.NameEnv (registerCtors, lookupCtorOwner)
-import Agda.Compiler.Scala.ScalaExpr (ScalaExpr(..), ScalaTerm(..), ScalaCtor(..))
 
 lowerCompile :: QName -> Either CompileError ScalaExpr -> ScalaExpr
 lowerCompile qn = either (\err -> SeUnhandled (show qn) (show err)) id
@@ -144,6 +138,21 @@ scalaCompileDef :: ScalaEnv
 scalaCompileDef _env modEnv _isMain def@Defn{defName = qn} =
   withCurrentModule (qnameModule qn) $ do
     modulePragma <- lookupScalaPragma qn
+    moduleDebugPragma <- lookupScalaDebugPragma qn
+    case moduleDebugPragma of
+      Nothing -> pure ()
+      Just _  -> liftIO $ do
+        --putStrLn "===== AGDA2SCALA DEBUG: Definition ====="
+        --putStrLn (show def)
+        --putStrLn "===== END DEBUG ====="
+
+        putStrLn "===== AGDA2SCALA DEBUG ====="
+        putStrLn ("QName: " <> show qn)
+        putStrLn "defType:"
+        putStrLn (show (defType def))
+        putStrLn "theDef:"
+        putStrLn (show (theDef def))
+        putStrLn "===== END DEBUG ====="
     case modulePragma of
       Nothing     -> pure (noPragmaResult def)
       Just pragma -> do
@@ -184,6 +193,12 @@ lookupScalaPragma defName = getUniqueCompilerPragma pragmaTag defName
 
 pragmaTag :: T.Text
 pragmaTag = T.pack "AGDA2SCALA"
+
+pragmaDebug :: T.Text
+pragmaDebug = T.pack "AGDA2SCALA_DEBUG"
+
+lookupScalaDebugPragma :: QName -> TCM (Maybe CompilerPragma)
+lookupScalaDebugPragma qn = getUniqueCompilerPragma pragmaDebug qn
 
 noPragmaResult :: Definition -> ScalaDefinition
 --noPragmaResult Defn{defName = defName} = SeUnhandled (show defName) "No AGDA2SCALA pragma" -- TODO filter Unhandled but show in logs

--- a/src/Agda/Compiler/Scala/Backend.hs
+++ b/src/Agda/Compiler/Scala/Backend.hs
@@ -159,7 +159,7 @@ scalaCompileDef _env modEnv _isMain def@Defn{defName = qn} =
         e   <- compileDefn def pragma   -- TCM (Either CompileError ScalaExpr)
         let expr = lowerCompile qn e    -- ScalaExpr
         case expr of
-          SeSum parent ctors -> do
+          SeSum parent _tyParams ctors -> do
             -- record ctor->parent mapping for later functions
             liftIO $ atomicModifyIORef' modEnv $ \ne ->
               let ne' = registerCtors parent ctors ne

--- a/src/Agda/Compiler/Scala/PrintScala2.hs
+++ b/src/Agda/Compiler/Scala/PrintScala2.hs
@@ -4,6 +4,7 @@ module Agda.Compiler.Scala.PrintScala2
   , printSealedTrait
   , printPackageAndObject
   , printCaseClass
+  , printSum
   , printType
   , combineLines
   , escapeScalaString
@@ -29,9 +30,8 @@ printScala2 def = case def of
       nl <> combineLines (map printScala2 defs)
     )
     <> nl
-  SeSum adtName ctors ->
-    printSealedTrait adtName <> nl <>
-    printCompanionObject adtName (map (printCtor adtName) ctors) <>
+  SeSum name tyParams ctors ->
+    printSum name tyParams ctors <>
     nl
   SeFun fName args resScheme body ->
     "def" <> sp <> fName <> printTyParams (ssTyParams resScheme) <>
@@ -39,25 +39,30 @@ printScala2 def = case def of
     ":" <> sp <> printType (ssType resScheme) <> sp <>
     "=" <> sp <> printTerm body <>
     nl
-  SeProd name args ->
-    printCaseClass name args <> nl
+  SeProd name tyParams args ->
+    printCaseClass name tyParams args <> nl
   SeUnhandled "" _payload ->
     ""  -- filtered out
   SeUnhandled name payload ->
     "/* TODO " <> show name <> " " <> show payload <> " */" <> nl
-  other ->
-    "/* unsupported printScala2: " <> show other <> " */" <> nl
 
 -- ===== Sum types ============================================================
 
-printCtor :: ScalaName -> ScalaCtor -> String
-printCtor superName (ScalaCtor cName []) =
-  printCaseObject superName cName
+printSum :: ScalaName -> [ScalaName] -> [ScalaCtor] -> String
+printSum name tyParams ctors =
+  printSealedTrait name <> printTyParams tyParams <> nl <>
+  printCompanionObject name (map (printCtor name tyParams) ctors)
 
-printCtor superName (ScalaCtor cName argTys) =
-  "final case class" <> sp <> cName <>
+printCtor :: ScalaName -> [ScalaName] -> ScalaCtor -> String
+printCtor superName tyParams (ScalaCtor cName []) =
+  printCaseObject (superName <> printTyParams (asBottom tyParams)) cName
+printCtor superName tyParams (ScalaCtor name argTys) =
+  "final case class" <> sp <> name <> printTyParams tyParams <>
   "(" <> intercalate ", " (zipWith ctorParam [0 :: Int ..] argTys) <> ")" <>
-  sp <> "extends" <> sp <> superName
+  sp <> "extends" <> sp <> superName <> printTyParams tyParams
+
+asBottom :: [ScalaName] -> [ScalaName]
+asBottom ps = replicate (length ps) "Nothing"
 
 ctorParam :: Int -> ScalaType -> String
 ctorParam i ty = "x" <> show i <> ":" <> sp <> printType ty
@@ -71,9 +76,9 @@ printCaseObject superName caseName =
 
 -- ===== Product types ========================================================
 
-printCaseClass :: ScalaName -> [SeVar] -> String
-printCaseClass name args =
-  "final case class" <> sp <> name <>
+printCaseClass :: ScalaName -> [ScalaName] -> [SeVar] -> String
+printCaseClass name tyParams args =
+  "final case class" <> sp <> name <> printTyParams tyParams <>
   "(" <> intercalate ", " (map printVar args) <> ")"
 
 -- ===== Terms ================================================================

--- a/src/Agda/Compiler/Scala/PrintScala3.hs
+++ b/src/Agda/Compiler/Scala/PrintScala3.hs
@@ -21,9 +21,8 @@ printScala3 def = case def of
     printPackageAndObject pNames
       <> bracket (map printScala3 defs)
       <> blankLine -- EOF
-  (SeSum adtName ctors) ->
-    printEnum adtName
-    <> bracketWithIndent (map printEnumCtor ctors) 2
+  (SeSum name tyParams ctors) ->
+    printSum name tyParams ctors
     <> defsSeparator
   (SeFun fName args resType funBody) ->
     "def" <> exprSeparator <> fName <> printTyParams (ssTyParams resType)
@@ -31,18 +30,33 @@ printScala3 def = case def of
     <> ":" <> exprSeparator <> printType (ssType resType) <> exprSeparator
     <> "=" <> exprSeparator <> printTerm funBody
     <> defsSeparator
-  (SeProd name args) -> printCaseClass name args <> defsSeparator
+  (SeProd name tyParams args) -> printCaseClass name args <> defsSeparator
   (SeUnhandled "" payload) -> ""
   (SeUnhandled name payload) -> "TODO " ++ show name ++ " " ++ show payload
-  other -> "unsupported printScala3 " ++ show other
 
-printEnumCtor :: ScalaCtor -> String
-printEnumCtor (ScalaCtor cName []) =
-  "case" <> exprSeparator <> cName
+-- ===== Sum types ============================================================
 
-printEnumCtor (ScalaCtor cName argTys) =
+printSum :: ScalaName -> [ScalaName] -> [ScalaCtor] -> String
+printSum name tyParams ctors =
+    printEnum name
+    <> printTyParams tyParams
+    <> bracketWithIndent (map (printEnumCtor name tyParams) ctors) 2
+
+printEnumCtor :: ScalaName -> [ScalaName] -> ScalaCtor -> String
+printEnumCtor name tyParams (ScalaCtor cName []) =
   "case" <> exprSeparator <> cName
+   <> printExtends name (asBottom tyParams)
+printEnumCtor name tyParams (ScalaCtor cName argTys) =
+  "case" <> exprSeparator <> cName <> printTyParams tyParams
   <> "(" <> intercalate ", " (zipWith ctorParam [0 :: Int ..] argTys) <> ")"
+  <> printExtends name tyParams
+
+asBottom :: [ScalaName] -> [ScalaName]
+asBottom ps = replicate (length ps) "Nothing"
+
+printExtends :: ScalaName -> [ScalaName] -> String
+printExtends name [] = ""
+printExtends name tyParams = " extends " <> name <> printTyParams tyParams
 
 ctorParam :: Int -> ScalaType -> String
 ctorParam i ty = "x" <> show i <> colonSeparator <> exprSeparator <> printType ty

--- a/src/Agda/Compiler/Scala/ScalaExpr.hs
+++ b/src/Agda/Compiler/Scala/ScalaExpr.hs
@@ -47,8 +47,8 @@ data ScalaCtor = ScalaCtor
 
 data ScalaExpr
   = SePackage [ScalaName] [ScalaExpr]
-  | SeSum ScalaName [ScalaCtor]
-  | SeProd ScalaName [SeVar]
+  | SeSum  ScalaName [ScalaName] [ScalaCtor]          -- name, type params, ctors
+  | SeProd ScalaName [ScalaName] [SeVar]              -- name, type params, fields
   | SeFun ScalaName [SeVar] ScalaTypeScheme ScalaTerm
   | SeUnhandled ScalaName String
   deriving (Eq, Show)

--- a/test/AgdaToScalaExprProps.hs
+++ b/test/AgdaToScalaExprProps.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
 
 module AgdaToScalaExprProps (tests) where
 
@@ -10,9 +9,10 @@ import Hedgehog
   , property
   , forAll
   , (===)
-  , Range(..)
-  , Gen(..)
+  , Range
+  , Gen
   , success
+  , failure
   )
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -24,10 +24,12 @@ import Agda.Compiler.Scala.AgdaToScalaExpr
   , compileTypeTerm
   , compileBodyTerm
   )
+import Agda.Compiler.Scala.AgdaToScalaExpr.Types (TyEnv(..), compileTypeTermWith)
 
 import Agda.Compiler.Scala.ScalaExpr (ScalaTerm(..), ScalaType(..))
 
-import Agda.Syntax.Internal (Term(..))
+import Agda.Syntax.Common (Arg(..))
+import Agda.Syntax.Internal (Term(..), Elim'(..))
 import Agda.Syntax.Literal (Literal(..))
 
 tests :: Group
@@ -143,3 +145,22 @@ prop_compileBodyTerm_literals = property $ do
   env <- forAll genEnv
   n <- forAll (Gen.integral (Range.linear 0 100000 :: Range Integer))
   compileBodyTerm env (Lit (LitNat n)) === Right (STeLitInt (fromIntegral n))
+
+-- type application preserves arity for Var - don’t “lose” type arguments
+prop_compileTypeTermWith_var_app_arity :: Property
+prop_compileTypeTermWith_var_app_arity = property $ do
+  -- TyEnv with one named type var at index 0
+  let tyEnv = TyEnv [Just "A"]  -- adjust constructor/import for your Types module
+
+  k <- forAll (Gen.int (Range.linear 0 5))
+  let elims = replicate k (Apply (Arg (error "arginfo") (Var 0 [])))
+      t     = Var 0 elims
+
+  case compileTypeTermWith tyEnv t of
+    Left _ -> failure
+    Right ty ->
+      case ty of
+        STyVar _ -> k === 0
+        STyApp _ args -> length args === k
+        _ -> failure
+

--- a/test/HedgehogMain.hs
+++ b/test/HedgehogMain.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import Hedgehog (Group(..), checkParallel)
+import Hedgehog (checkParallel)
 import qualified NameEnvProps
 import qualified PrintProps
 import qualified AgdaToScalaExprProps

--- a/test/NameEnvProps.hs
+++ b/test/NameEnvProps.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Property tests for NameEnv.
@@ -13,7 +12,7 @@ import Data.Char (isAlphaNum, isLetter)
 import Data.List (mapAccumL, nub)
 import qualified Data.Set as Set
 
-import Hedgehog (Group(..), Gen(..), Property, PropertyName(..), GroupName(..), property, forAll, assert, (===))
+import Hedgehog (Group(..), Gen, Property, property, forAll, assert, (===))
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 

--- a/test/NameEnvTest.hs
+++ b/test/NameEnvTest.hs
@@ -1,6 +1,6 @@
 module NameEnvTest (nameEnvTests) where
 
-import Test.HUnit
+import Test.HUnit (Test(..), assertEqual, assertBool)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 

--- a/test/PrintScala2Test.hs
+++ b/test/PrintScala2Test.hs
@@ -6,6 +6,7 @@ import Agda.Compiler.Scala.PrintScala2
   , printSealedTrait
   , printCaseObject
   , printPackageAndObject
+  , printSum
   , combineLines
   , printCaseClass
   )
@@ -59,10 +60,18 @@ testPrintCaseClass :: Test
 testPrintCaseClass = TestCase $
   assertEqual "printCaseClass"
     "final case class RgbPair(snd: Bool, fst: Rgb)"
-    (printCaseClass "RgbPair"
+    (printCaseClass "RgbPair" []
       [ SeVar "snd" (STyName "Bool")
       , SeVar "fst" (STyName "Rgb")
       ])
+
+testPrintCaseClassPoly :: Test
+testPrintCaseClassPoly = TestCase $
+  assertEqual "printCaseClassPolymorphic"
+    "final case class Box[A](unbox: A)"
+    (printCaseClass "Box"
+      ["A"]
+      [ SeVar "unbox" (STyVar "A")])
 
 testPrintScala2 :: Test
 testPrintScala2 = TestCase $
@@ -71,13 +80,13 @@ testPrintScala2 = TestCase $
     (printScala2 $ SePackage ["adts"] moduleContent)
   where
     rgbAdt =
-      SeSum "Rgb"
+      SeSum "Rgb" []
         [ ScalaCtor "Red"   []
         , ScalaCtor "Green" []
         , ScalaCtor "Blue"  []
         ]
     colorAdt =
-      SeSum "Color"
+      SeSum "Color" []
         [ ScalaCtor "Light" []
         , ScalaCtor "Dark"  []
         ]
@@ -102,6 +111,42 @@ testPrintScala2 = TestCase $
       "\n" <>          -- likewise
       "}\n" <>
       "}\n"
+
+testPrintSum:: Test
+testPrintSum = TestCase $
+  assertEqual "testPrintSum"
+    expected
+    (printSum "Rgb" []
+                        [ ScalaCtor "Red"   []
+                        , ScalaCtor "Green" []
+                        , ScalaCtor "Blue"  []
+                        ])
+  where
+    expected =
+      "sealed trait Rgb\n" <>
+      "object Rgb {\n" <>
+      "  case object Red extends Rgb\n" <>
+      "  case object Green extends Rgb\n" <>
+      "  case object Blue extends Rgb\n" <>
+      "\n" <>
+      "}"
+
+testPrintSumPoly :: Test
+testPrintSumPoly = TestCase $
+  assertEqual "testPrintSumPoly"
+    expected
+    (printSum "Maybe" ["A"]
+                        [ ScalaCtor "None"   []
+                        , ScalaCtor "Just" [STyVar "A"]
+                        ])
+  where
+    expected =
+      "sealed trait Maybe[A]\n" <>
+      "object Maybe {\n" <>
+      "  case object None extends Maybe[Nothing]\n" <>
+      "  final case class Just[A](x0: A) extends Maybe[A]\n" <>
+      "\n" <>
+      "}"
 
 testPolyDef :: Test
 testPolyDef = TestCase $
@@ -128,6 +173,9 @@ printScala2Tests = TestList
   , TestLabel "printPackageAndObject 2" testPrintMultiplePartPackageAndObject
   , TestLabel "combineLines" testCombineLines
   , TestLabel "printCaseClass" testPrintCaseClass
+  , TestLabel "printCaseClassPolymorphic" testPrintCaseClassPoly
+  , TestLabel "testPrintSum" testPrintSum
+  , TestLabel "testPrintSumPoly" testPrintSumPoly
   , TestLabel "printScala2" testPrintScala2
   , TestLabel "printScala2 polymorphic def" testPolyDef
   ]

--- a/test/PrintScala3Test.hs
+++ b/test/PrintScala3Test.hs
@@ -56,13 +56,13 @@ testPrintScala3 = TestCase $
     (printScala3 $ SePackage ["adts"] moduleContent)
   where
     rgbAdt =
-      SeSum "Rgb"
+      SeSum "Rgb" []
         [ ScalaCtor "Red"   []
         , ScalaCtor "Green" []
         , ScalaCtor "Blue"  []
         ]
     colorAdt =
-      SeSum "Color"
+      SeSum "Color" []
         [ ScalaCtor "Light" []
         , ScalaCtor "Dark"  []
         ]

--- a/test/ScalaBackendTest.hs
+++ b/test/ScalaBackendTest.hs
@@ -61,7 +61,7 @@ testShouldWriteModule = TestCase $ do
   assertEqual "all unhandled => don't write"
     False (shouldWriteModule [SeUnhandled "" ""])
   assertEqual "some handled => write"
-    True (shouldWriteModule [SeUnhandled "" "", SeSum "Rgb" [ScalaCtor{scName = "Red", scArgs = [] } ]] )
+    True (shouldWriteModule [SeUnhandled "" "", SeSum "Rgb" [] [ScalaCtor{scName = "Red", scArgs = [] } ]] )
 
 backendTests :: Test
 backendTests = TestList [

--- a/test/TypesProps.hs
+++ b/test/TypesProps.hs
@@ -1,0 +1,96 @@
+module TypesProps (tests) where
+
+import Hedgehog (Group(..), Gen(..), Property, property, forAll, (===))
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import Agda.Compiler.Scala.AgdaToScalaExpr.Types
+  ( TyEnv(..)
+  , compileTypeTermWith
+  , lookupTyVar
+  )
+
+import Agda.Compiler.Scala.ScalaExpr (ScalaType(..))
+
+import Agda.Syntax.Internal (Term(..), Elim'(..))
+import Agda.Syntax.Common (Arg(..))
+
+tests :: Group
+tests =
+  Group "TypesProps"
+    [ ("prop_lookupTyVar_resolves_named", prop_lookupTyVar_resolves_named)
+    , ("prop_compileTypeTermWith_varApp_arity", prop_compileTypeTermWith_varApp_arity)
+    , ("prop_compileTypeTermWith_shifted_index", prop_compileTypeTermWith_shifted_index)
+    ]
+
+-- | TyEnv lookup sanity: resolve named type variables at the right de Bruijn index.
+--
+-- In Agda internal syntax, type variables are de Bruijn indexed (Var 0 = most recent binder).
+-- Our TyEnv mirrors the *full* binder stack:
+--   Just "A"  = a type parameter we want to surface in Scala
+--   Nothing   = a term binder (kept only to keep indices aligned)
+--
+-- This property pins two essential facts:
+--   1) If the most recent binder is a type param, index 0 resolves to that name.
+--   2) If we have one intervening term binder, the same type param shifts to index 1.
+--
+-- Regression prevented: returning "tN" for a type param that should resolve to "A"
+-- (common when TyEnv doesn't include term binders).
+prop_lookupTyVar_resolves_named :: Property
+prop_lookupTyVar_resolves_named = property $ do
+  -- env[0] is most recent binder
+  lookupTyVar (TyEnv [Just "A"]) 0 === "A"
+  lookupTyVar (TyEnv [Nothing, Just "A"]) 1 === "A"
+
+-- | Type application arity is preserved when compiling a Var with Apply-eliminations.
+--
+-- Agda encodes type application via eliminations:
+--   Var n [Apply a1, Apply a2, ...]
+-- represents applying a type variable to arguments (e.g. F A B).
+--
+-- Our compiler should translate this to:
+--   STyVar name              when there are 0 Apply args
+--   STyApp name [t1, t2, ..] when there are k Apply args
+--
+-- This property checks the *arity* invariant:
+--   the number of Apply arguments in the Agda term equals the number of arguments
+--   in the resulting STyApp.
+--
+-- Regression prevented:
+--   - silently dropping type arguments (producing STyVar instead of STyApp),
+--   - or compiling only some of the Apply args.
+prop_compileTypeTermWith_varApp_arity :: Property
+prop_compileTypeTermWith_varApp_arity = property $ do
+  k <- forAll (Gen.int (Range.linear 0 5))
+
+  let env   = TyEnv [Just "A"]
+      argT  = Var 0 []  -- a type variable as an argument
+      elims = replicate k (Apply (Arg (error "ArgInfo not needed") argT))
+      t     = Var 0 elims
+
+  case compileTypeTermWith env t of
+    Left _ -> failure
+    Right ty -> case ty of
+      STyVar _      -> k === 0
+      STyApp _ args -> length args === k
+      _             -> failure
+
+-- | De Bruijn index shifting across term binders in types.
+--
+-- Agda uses ONE de Bruijn index space for both type and term binders.
+-- Example:
+--   id : {A : Type u} -> A -> A
+-- The return type 'A' is often represented as Var 1, because the term binder
+-- (x : A) becomes the most recent binder (Var 0) and shifts 'A' to index 1.
+--
+-- Our TyEnv stores term binders as Nothing specifically to preserve this alignment.
+--
+-- This property asserts the observable consequence:
+--   in an environment [Nothing, Just "A"], Var 1 must resolve to STyVar "A".
+--
+-- Regression prevented: generating "t1" for polymorphic return types (e.g. def id[A](x: A): t1).
+prop_compileTypeTermWith_shifted_index :: Property
+prop_compileTypeTermWith_shifted_index = property $ do
+  -- After one term binder, original type param "A" shifts from index 0 to index 1.
+  let env = TyEnv [Nothing, Just "A"]
+  compileTypeTermWith env (Var 1 []) === Right (STyVar "A")

--- a/test/TypesTest.hs
+++ b/test/TypesTest.hs
@@ -1,0 +1,20 @@
+module TypesTest (tests) where
+
+import Test.HUnit (Test(..), assertBool)
+
+import Agda.Compiler.Scala.AgdaToScalaExpr.Types (isTypeLike)
+import Agda.Syntax.Internal (Type, Type''(..), Term(..))
+
+tests :: Test
+tests = TestLabel "TypesTest" (TestList [test_isTypeLike_sort, test_isTypeLike_piToSort])
+
+-- A : Type u  ==> El _ (Sort _)
+test_isTypeLike_sort :: Test
+test_isTypeLike_sort = TestCase $
+  assertBool "Sort is type-like" (isTypeLike (El (error "sort-ann") (Sort (error "Sort payload"))))
+
+-- F : Type u -> Type u ==> El _ (Pi _ -> Sort _)
+test_isTypeLike_piToSort :: Test
+test_isTypeLike_piToSort = TestCase $
+  assertBool "Pi ... -> Sort is type-like"
+    (isTypeLike (El (error "sort-ann") (Pi (error "dom") (error "abs"))))


### PR DESCRIPTION
## Changes:
* add support for pragma for debugging `{-# COMPILE AGDA2SCALA_DEBUG Maybe #-}`
* support polymorhic product types and sum types

# Support polymorhic product types and sum types:

* Fix implicit-binder classification + add type application in compileTypeTermWith

Add a pure predicate isTypeLike :: Type -> Bool
```
A : Type u shows up as El _ (Sort …) ⇒ true
F : Type u -> Type u shows up as El _ (Pi … (Sort …)) ⇒ true (higher-kinded)
```
Implicit term args (e.g. {n : Nat}) are not Sort/Pi..Sort ⇒ false

Update funSchemeFromType binder fold:
if binder is Hidden and isTypeLike ⇒ treat as Scala type param (ssTyParams)
otherwise treat as term binder (still possibly hidden, but it shifts indices!)

Update compileTypeTermWith to translate eliminations:
```
Def qn elims with Apply args ⇒ STyApp name [argTypes...]
Var n elims similarly ⇒ STyApp (lookupTyVar n) [...]
```

* Step 2: Add type params to data types in your Scala AST and printers

```
SeSum ScalaName [ScalaName] [ScalaCtor]
SeProd ScalaName [ScalaName] [SeVar]
```

Printers:
```
Scala2: sealed trait Maybe[A], companion object Maybe { ... }
Scala3: enum Maybe[A]: ...
```
* Compile datatype parameters from Definition.defType

For a Datatype definition, run the same Pi analysis you do for functions: extract type params + TyEnv
Use that TyEnv when compiling constructors (so constructor arg types resolve A, not tN)
Use type params list to populate SeSum/SeProd
* Unit test: isTypeLike distinguishes Type-binders
* properties:
  * type application preserves arity for Var
  * ctorArgTypesFromTypeWith updates env after each explicit binder
  * compileTypeTermWith preserves arity under application
  * ctorArgTypesFromTypeWith preserves “same type param” across later args
 

This change:
* fix #13 