### PR TITLE
Add GitHub Actions workflow for security scanning

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -1,0 +1,40 @@
+name: security
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  cabal-audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up GHC
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.10.1'
+          cabal-version: '3.10.3'
+          cabal-update: true
+
+      - name: Build plan
+        run: |
+          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal build --dry-run
+
+      - name: Install cabal-audit
+        run: cabal install cabal-audit
+
+      - name: Run cabal-audit
+        run: ~/.cabal/bin/cabal-audit --sarif -o cabal-audit.sarif
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: cabal-audit.sarif
+          category: cabal-audit


### PR DESCRIPTION
Use `cabal-audit` to scan for vulnerabilities and [upload SARIF code to Github](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/uploading-a-sarif-file-to-github?utm_source=chatgpt.com)
`SARIF` / code scanning results show up in the repo under `Security and quality -> Code scanning`