### PR TITLE
Add cabal audit in GitHub Actions workflow

### DIFF
--- a/.github/workflows/security-code-scanning.yml
+++ b/.github/workflows/security-code-scanning.yml
@@ -1,13 +1,21 @@
-name: security
+name: Security code scanning
 
-on: [push] # TODO temporary for testing
-#on:
-#  push:
-#    branches: [main]
+on:
+  push:
+    branches: [main]
+  # manual re-run  
+  workflow_dispatch:  
+
+# cancel duplicated runs
+concurrency:
+  group: security-code-scanning-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   cabal-audit:
+    name: cabal-audit SARIF
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,50 @@
+name: security
+
+on: [push] # TODO temporary for testing
+#on:
+#  push:
+#    branches: [main]
+
+jobs:
+  cabal-audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up GHC
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.10.1'
+          cabal-version: '3.12.1.0'
+          cabal-update: true
+
+      - name: Build plan
+        run: |
+          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal build --dry-run
+
+      - name: Check out MangoIV/cabal-audit
+        uses: actions/checkout@v6
+        with:
+          repository: MangoIV/cabal-audit
+          path: cabal-audit-src
+
+      - name: Install cabal-audit from source
+        run: |
+          cd cabal-audit-src
+          cabal install exe:cabal-audit --installdir="$HOME/.local/bin" --overwrite-policy=always
+
+      - name: Run cabal-audit
+        run: |
+          "$HOME/.local/bin/cabal-audit" --sarif -o cabal-audit.sarif
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: cabal-audit.sarif
+          category: cabal-audit


### PR DESCRIPTION
Use `cabal-audit` to scan for vulnerabilities and [upload SARIF code to Github](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/uploading-a-sarif-file-to-github?utm_source=chatgpt.com)
`SARIF` / code scanning results show up in the repo under `Security and quality -> Code scanning`