### PR TITLE
Split ADT for expressions into Scala IR and Agda IR

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ object adts:
 
 More [Agda examples](./examples/adts.agda)
 
+## Architecture
+
+We use 2 internal representation
+1 AgdaIR is close to Agda compiler representation
+2. ScalaIR is close to Scala language representation
+
+```text
+             TCM glue                      prettyPrint
+Definition ==========> AgdaIR ==> ScalaIR ============> String
+```
+
+At the end we choose between Scala2 and Scala3 syntax.
+Possible future directions: Kotlin, Java, JVM bytecode
+
 ## Identifier mapping
 
 Agda constructor names are not always valid Scala identifiers (e.g. `[]`).

--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -43,6 +43,10 @@ library
     Agda.Compiler.Scala.PrintScala2
     Agda.Compiler.Scala.PrintScala3
     Agda.Compiler.Scala.ScalaExpr
+    Agda.Compiler.Scala.IR.Agda
+    Agda.Compiler.Scala.IR.Scala
+    Agda.Compiler.Scala.Lower.AgdaToIR
+    Agda.Compiler.Scala.Lower.IRToScala
     Paths_agda2scala
 
   autogen-modules:  Paths_agda2scala

--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -104,6 +104,7 @@ test-suite agda2scala-hedgehog
     NameEnvProps
     NamePolicyProps
     PrintProps
+    IRToScalaProps
 
   build-depends:
     , Agda                  >=2.8.0  && <2.9.0

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr.hs
@@ -1,153 +1,39 @@
-{-# LANGUAGE LambdaCase #-}
+module Agda.Compiler.Scala.AgdaToScalaExpr
+  ( compileDefn
+  , CompileError(..)
+  , compileTypeTerm
+  , compileBodyTerm
+  , lookupVar
+  , Env(..)
+  ) where
 
-module Agda.Compiler.Scala.AgdaToScalaExpr (
-    compileDefn,
-    CompileError (..),
-    compileTypeTerm,
-    compileBodyTerm,
-    lookupVar,
-    Env (..),
-) where
+import Agda.Compiler.Backend (CompilerPragma)
+import Agda.TypeChecking.Monad (TCM)
+import Agda.TypeChecking.Monad.Base (Definition)
 
-import Control.Monad (foldM)
+import Agda.Compiler.Scala.AgdaToScalaExpr.Terms
+  ( Env(..)
+  , compileBodyTerm
+  , lookupVar
+  )
+import Agda.Compiler.Scala.AgdaToScalaExpr.Types
+  ( CompileError(..)
+  , compileTypeTerm
+  )
+import Agda.Compiler.Scala.Lower.AgdaToIR
+  ( lowerDefinition
+  )
+import Agda.Compiler.Scala.Lower.IRToScala
+  ( toScalaExpr
+  )
+import Agda.Compiler.Scala.NamePolicy
+  ( defaultNamePolicy
+  )
+import Agda.Compiler.Scala.ScalaExpr
+  ( ScalaExpr
+  )
 
-import Agda.Compiler.Backend -- TODO explicitly list dependencies
-import Agda.Compiler.Backend (CompilerPragma, Defn (..), RecordData (..), funCompiled)
-import Agda.Syntax.Abstract.Name ()
-import Agda.Syntax.Common (Hiding (..), getHiding)
-import Agda.Syntax.Internal (Abs, Dom (..), Tele (..), Telescope, Type, Type'' (..))
-import Agda.TypeChecking.CompiledClause (CompiledClauses)
-import Agda.TypeChecking.Monad (TCM, getConstInfo)
-import Agda.TypeChecking.Monad.Base (Definition (..))
-import Agda.TypeChecking.Substitute (absBody)
-
-import Agda.Compiler.Scala.ScalaExpr (
-    ScalaCtor (..),
-    ScalaExpr (..),
-    ScalaName,
-    SeVar (..),
- )
-
-import Agda.Compiler.Scala.AgdaToScalaExpr.Types (
-    CompileError (..),
-    TyEnv (..),
-    binderName,
-    compileDomTypeWith,
-    compileTypeTerm,
-    ctorArgTypesFromType,
-    ctorArgTypesFromTypeWith,
-    dataTyParamsFromType,
-    emptyTyEnv,
-    fromQName,
-    funSchemeFromType,
-    pushTermBinder,
-    pushTyParam,
-    unrollPi,
- )
-
-import Agda.Compiler.Scala.AgdaToScalaExpr.Terms (
-    Env (..),
-    compileBodyTerm,
-    compileFunctionBody,
-    lookupVar,
- )
-import Agda.Compiler.Scala.NamePolicy (ctorName, defaultNamePolicy)
-
--- ===== Entry point ===========================================================
-
-{- | Compile an Agda 'Definition' to Scala AST or return a structured error.
-Agda.TypeChecking.Monad.Base.Definition:
-https://hackage.haskell.org/package/Agda/docs/Agda-TypeChecking-Monad-Base.html#t:Definition
--}
 compileDefn :: Definition -> CompilerPragma -> TCM (Either CompileError ScalaExpr)
-compileDefn def _pragma = compileDefinition def
-
-compileDefinition :: Definition -> TCM (Either CompileError ScalaExpr)
-compileDefinition = \case
-    Defn{theDef = Datatype{dataCons = cons}, defName = qn, defType = ty} ->
-        compileDataType qn ty cons
-    Defn{theDef = Function{funCompiled = cc}, defName = qn, defType = ty} ->
-        pure (compileFunction qn ty cc)
-    Defn{theDef = RecordDefn (RecordData{_recTel = tel}), defName = qn, defType = ty} ->
-        pure (compileRecord qn ty tel)
-    Defn{defName = qn} ->
-        pure (Left (UnsupportedDefinition qn))
-
--- ===== Records ===============================================================
-
-{- | Compile a record telescope into a Scala case class.
-Agda.Syntax.Internal.Telescope (list-like):
-https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Internal.html#t:Telescope
--}
-compileRecord :: QName -> Type -> Telescope -> Either CompileError ScalaExpr
-compileRecord qn recTy tel = do
-    (tps, tyEnv) <- dataTyParamsFromType recTy
-    vars <- traverse (compileField tyEnv) (zip [0 :: Int ..] (teleToList tel))
-    pure (SeProd (fromQName qn) tps vars)
-  where
-    compileField :: TyEnv -> (Int, Dom Type) -> Either CompileError SeVar
-    compileField tyEnv (i, dom) = do
-        ty <- compileDomTypeWith tyEnv dom
-        pure (SeVar (binderName i dom) ty)
-
--- Agda.Syntax.Internal.Tele / Telescope:
--- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Internal.html#t:Tele
--- Telescope is a linked structure, not a list.
-teleToList :: Telescope -> [Dom Type]
-teleToList = \case
-    EmptyTel -> []
-    ExtendTel dom t -> dom : teleToList (absBody t)
-
--- ===== Datatypes / constructors =============================================
-
-compileDataType :: QName -> Type -> [QName] -> TCM (Either CompileError ScalaExpr)
-compileDataType typeName typeTy cons = do
-    let eParams = dataTyParamsFromType typeTy
-    eCtors <- traverse (compileCtorWith eParams) cons
-    pure $ do
-        (tps, _tyEnv) <- eParams
-        ctors <- sequence eCtors
-        pure (SeSum (fromQName typeName) tps ctors)
-
--- Compile constructors using the datatype TyEnv
-compileCtorWith ::
-    Either CompileError ([ScalaName], TyEnv) ->
-    QName ->
-    TCM (Either CompileError ScalaCtor)
-compileCtorWith eParams conQName = do
-    conDef <- getConstInfo conQName
-    let conTy = defType conDef
-    pure $ do
-        (_tps, tyEnv) <- eParams
-        argTys <- ctorArgTypesFromTypeWith tyEnv conTy
-        pure
-            ScalaCtor
-                { scName = ctorName defaultNamePolicy (fromQName conQName)
-                , scArgs = argTys
-                }
-
-compileCtor :: QName -> TCM (Either CompileError ScalaCtor)
-compileCtor conQName = do
-    conDef <- getConstInfo conQName
-    let conTy = defType conDef
-    pure $ do
-        argTys <- ctorArgTypesFromType conTy
-        pure
-            ScalaCtor
-                { scName = ctorName defaultNamePolicy (fromQName conQName)
-                , scArgs = argTys
-                }
-
--- ===== Functions =============================================================
-
-compileFunction ::
-    QName ->
-    Type ->
-    Maybe CompiledClauses ->
-    Either CompileError ScalaExpr
-compileFunction qn defTy mcc = do
-    (args, scheme) <- funSchemeFromType defTy
-    body <- compileFunctionBody (argNames args) mcc
-    pure (SeFun (fromQName qn) args scheme body)
-  where
-    argNames = map (\(SeVar n _) -> n)
+compileDefn def pragma = do
+  eDecl <- lowerDefinition def pragma
+  pure (toScalaExpr defaultNamePolicy <$> eDecl)

--- a/src/Agda/Compiler/Scala/AgdaToScalaExpr/Terms.hs
+++ b/src/Agda/Compiler/Scala/AgdaToScalaExpr/Terms.hs
@@ -8,6 +8,8 @@ module Agda.Compiler.Scala.AgdaToScalaExpr.Terms (
     compileBodyTerm,
 ) where
 
+
+import Data.Maybe (catMaybes)
 import Agda.Syntax.Common (Arg (..))
 import Agda.Syntax.Internal (ConHead (..), Elim' (..), Term (..))
 import Agda.Syntax.Literal (Literal (..))
@@ -50,24 +52,40 @@ compileFunctionBody argNs (Just cc) =
 
 compileBodyTerm :: Env -> Term -> Either CompileError ScalaTerm
 compileBodyTerm env = \case
-    Var i _ -> STeVar <$> lookupVar env i
-    Def qn _ -> pure (STeVar (fromQName qn))
+    Var i elims -> do
+        f <- STeVar <$> lookupVar env i
+        applyElims env f elims
+    Def qn elims -> do
+        let f = STeVar (fromQName qn)
+        applyElims env f elims
     Con ch _ es -> compileConApp env ch es
     Lit lit -> compileLiteral lit
     t -> Left (UnsupportedTerm t)
 
 compileConApp :: Env -> ConHead -> [Elim' Term] -> Either CompileError ScalaTerm
 compileConApp env conHead elims = do
-    args <- traverse (compileElim env) elims
+    args <- fmap catMaybes (traverse (compileElimMaybe env) elims)
     let f = STeVar (ctorName defaultNamePolicy (fromQName (conName conHead)))
     pure $ case args of
         [] -> f
-        _ -> STeApp f args
+        _  -> STeApp f args
 
-compileElim :: Env -> Elim' Term -> Either CompileError ScalaTerm
-compileElim env = \case
-    Apply a -> compileBodyTerm env (unArg a)
-    _ -> Left (UnsupportedTerm (Var 0 [])) -- refine later (Proj/IApply)
+applyElims :: Env -> ScalaTerm -> [Elim' Term] -> Either CompileError ScalaTerm
+applyElims env f elims = do
+    args <- fmap catMaybes (traverse (compileElimMaybe env) elims)
+    pure $ case args of
+        [] -> f
+        _  -> STeApp f args
+
+compileElimMaybe :: Env -> Elim' Term -> Either CompileError (Maybe ScalaTerm)
+compileElimMaybe env = \case
+    Apply a ->
+        case unArg a of
+            -- erase universe-level artifacts at term level
+            Level _ -> pure Nothing
+            Sort _  -> pure Nothing
+            t       -> Just <$> compileBodyTerm env t
+    _ -> Left (UnsupportedTerm (Var 0 [])) -- Proj/IApply later
 
 compileLiteral :: Literal -> Either CompileError ScalaTerm
 compileLiteral = \case

--- a/src/Agda/Compiler/Scala/Backend.hs
+++ b/src/Agda/Compiler/Scala/Backend.hs
@@ -207,7 +207,7 @@ lookupScalaDebugPragma qn = getUniqueCompilerPragma pragmaDebug qn
 
 noPragmaResult :: Definition -> ScalaDefinition
 -- noPragmaResult Defn{defName = defName} = SeUnhandled (show defName) "No AGDA2SCALA pragma" -- TODO filter Unhandled but show in logs
-noPragmaResult def = SeUnhandled "" ""
+noPragmaResult _def = SeUnhandled "" ""
 
 scalaPostCompile ::
     ScalaEnv ->

--- a/src/Agda/Compiler/Scala/IR/Agda.hs
+++ b/src/Agda/Compiler/Scala/IR/Agda.hs
@@ -1,0 +1,39 @@
+module Agda.Compiler.Scala.IR.Agda
+  ( AgdaDecl(..)
+  , AgdaData(..)
+  , AgdaRecord(..)
+  , AgdaFun(..)
+  ) where
+
+import Agda.Compiler.Scala.ScalaExpr
+  ( ScalaCtor
+  , ScalaName
+  , ScalaTerm
+  , ScalaTypeScheme
+  , SeVar
+  )
+
+data AgdaDecl
+  = DData   AgdaData
+  | DRecord AgdaRecord
+  | DFun    AgdaFun
+  deriving (Eq, Show)
+
+data AgdaData = AgdaData
+  { adName     :: ScalaName
+  , adTyParams :: [ScalaName]
+  , adCtors    :: [ScalaCtor]
+  } deriving (Eq, Show)
+
+data AgdaRecord = AgdaRecord
+  { arName     :: ScalaName
+  , arTyParams :: [ScalaName]
+  , arFields   :: [SeVar]
+  } deriving (Eq, Show)
+
+data AgdaFun = AgdaFun
+  { afName   :: ScalaName
+  , afArgs   :: [SeVar]
+  , afScheme :: ScalaTypeScheme
+  , afBody   :: ScalaTerm
+  } deriving (Eq, Show)

--- a/src/Agda/Compiler/Scala/IR/Scala.hs
+++ b/src/Agda/Compiler/Scala/IR/Scala.hs
@@ -1,0 +1,16 @@
+module Agda.Compiler.Scala.IR.Scala
+  ( ScalaModule(..)
+  , ScalaExpr(..)
+  , ScalaType(..)
+  , ScalaTypeScheme(..)
+  , ScalaTerm(..)
+  , ScalaCtor(..)
+  , SeVar(..)
+  ) where
+
+import Agda.Compiler.Scala.ScalaExpr
+
+data ScalaModule = ScalaModule
+  { smPackage :: [ScalaName]
+  , smDecls   :: [ScalaExpr]
+  } deriving (Eq, Show)

--- a/src/Agda/Compiler/Scala/Lower/AgdaToIR.hs
+++ b/src/Agda/Compiler/Scala/Lower/AgdaToIR.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
+
+-- handle interactions with Agda interlans
+module Agda.Compiler.Scala.Lower.AgdaToIR
+  ( lowerDefinition
+  ) where
+
+import Agda.Compiler.Backend
+  ( CompilerPragma
+  , Defn(..)
+  , RecordData(..)
+  , funCompiled
+  , dataCons
+  , pattern Datatype
+  , pattern Function
+  )
+import Agda.Syntax.Abstract.Name (QName)
+import Agda.Syntax.Internal
+  ( Dom
+  , Tele(..)
+  , Telescope
+  , Type
+  )
+import Agda.TypeChecking.CompiledClause (CompiledClauses)
+import Agda.TypeChecking.Monad (TCM, getConstInfo)
+import Agda.TypeChecking.Monad.Base (Definition(..))
+import Agda.TypeChecking.Substitute (absBody)
+
+import Agda.Compiler.Scala.AgdaToScalaExpr.Terms
+  ( compileFunctionBody
+  )
+import Agda.Compiler.Scala.AgdaToScalaExpr.Types
+  ( CompileError(..)
+  , TyEnv
+  , binderName
+  , compileDomTypeWith
+  , ctorArgTypesFromTypeWith
+  , dataTyParamsFromType
+  , fromQName
+  , funSchemeFromType
+  )
+import Agda.Compiler.Scala.IR.Agda
+  ( AgdaData(..)
+  , AgdaDecl(..)
+  , AgdaFun(..)
+  , AgdaRecord(..)
+  )
+import Agda.Compiler.Scala.ScalaExpr
+  ( ScalaCtor(..)
+  , ScalaName
+  , SeVar(..)
+  )
+
+lowerDefinition :: Definition -> CompilerPragma -> TCM (Either CompileError AgdaDecl)
+lowerDefinition def _pragma = case def of
+  Defn{theDef = Datatype{dataCons = cons}, defName = qn, defType = ty} ->
+    lowerData qn ty cons
+
+  Defn{theDef = RecordDefn (RecordData{_recTel = tel}), defName = qn, defType = ty} ->
+    pure (DRecord <$> lowerRecord qn ty tel)
+
+  Defn{theDef = Function{funCompiled = cc}, defName = qn, defType = ty} ->
+    pure (DFun <$> lowerFun qn ty cc)
+
+  Defn{defName = qn} ->
+    pure (Left (UnsupportedDefinition qn))
+
+-- ===== Records ===============================================================
+
+lowerRecord :: QName -> Type -> Telescope -> Either CompileError AgdaRecord
+lowerRecord qn recTy tel = do
+  (tps, tyEnv) <- dataTyParamsFromType recTy
+  fields <- traverse (lowerField tyEnv) (zip [0 :: Int ..] (teleToList tel))
+  pure
+    AgdaRecord
+      { arName = fromQName qn
+      , arTyParams = tps
+      , arFields = fields
+      }
+
+lowerField :: TyEnv -> (Int, Dom Type) -> Either CompileError SeVar
+lowerField tyEnv (i, dom) = do
+  ty <- compileDomTypeWith tyEnv dom
+  pure (SeVar (binderName i dom) ty)
+
+-- Agda.Syntax.Internal.Tele / Telescope:
+-- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Internal.html#t:Tele
+--
+-- Telescope is linked, not a normal Haskell list.
+teleToList :: Telescope -> [Dom Type]
+teleToList = \case
+  EmptyTel ->
+    []
+  ExtendTel dom rest ->
+    dom : teleToList (absBody rest)
+
+-- ===== Datatypes =============================================================
+
+lowerData :: QName -> Type -> [QName] -> TCM (Either CompileError AgdaDecl)
+lowerData typeName typeTy cons = do
+  let eParams = dataTyParamsFromType typeTy
+  eCtors <- traverse (lowerCtor eParams) cons
+  pure $ do
+    (tps, _tyEnv) <- eParams
+    ctors <- sequence eCtors
+    pure
+      ( DData
+          AgdaData
+            { adName = fromQName typeName
+            , adTyParams = tps
+            , adCtors = ctors
+            }
+      )
+
+lowerCtor
+  :: Either CompileError ([ScalaName], TyEnv)
+  -> QName
+  -> TCM (Either CompileError ScalaCtor)
+lowerCtor eParams conQName = do
+  conDef <- getConstInfo conQName
+  let conTy = defType conDef
+  pure $ do
+    (_tps, tyEnv) <- eParams
+    argTys <- ctorArgTypesFromTypeWith tyEnv conTy
+    pure
+      ScalaCtor
+        { scName = fromQName conQName
+        , scArgs = argTys
+        }
+
+-- ===== Functions =============================================================
+
+lowerFun
+  :: QName
+  -> Type
+  -> Maybe CompiledClauses
+  -> Either CompileError AgdaFun
+lowerFun qn defTy mcc = do
+  (args, scheme) <- funSchemeFromType defTy
+  body <- compileFunctionBody (argNames args) mcc
+  pure
+    AgdaFun
+      { afName = fromQName qn
+      , afArgs = args
+      , afScheme = scheme
+      , afBody = body
+      }
+  where
+    argNames = map (\(SeVar n _) -> n)

--- a/src/Agda/Compiler/Scala/Lower/IRToScala.hs
+++ b/src/Agda/Compiler/Scala/Lower/IRToScala.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- lower AgdaIR to ScalaIR
+-- NamePolicy: Agda names -> Scala identifiers
+module Agda.Compiler.Scala.Lower.IRToScala
+  ( toScalaExpr
+  ) where
+
+import Agda.Compiler.Scala.IR.Agda
+  ( AgdaData(..)
+  , AgdaDecl(..)
+  , AgdaFun(..)
+  , AgdaRecord(..)
+  )
+import Agda.Compiler.Scala.NamePolicy
+  ( NamePolicy
+  , ctorName
+  , termName
+  , typeName
+  )
+import Agda.Compiler.Scala.ScalaExpr
+  ( ScalaCtor(..)
+  , ScalaExpr(..)
+  , ScalaName
+  , ScalaTerm(..)
+  , SeVar(..)
+  )
+
+toScalaExpr :: NamePolicy -> AgdaDecl -> ScalaExpr
+toScalaExpr policy =
+  \case
+    DData d ->
+      SeSum
+        (typeName policy (adName d))
+        (adTyParams d)
+        (map (lowerCtor policy) (adCtors d))
+
+    DRecord r ->
+      SeProd
+        (typeName policy (arName r))
+        (arTyParams r)
+        (map (lowerField policy) (arFields r))
+
+    DFun f ->
+      SeFun
+        (termName policy (afName f))
+        (map (lowerField policy) (afArgs f))
+        (afScheme f)
+        (lowerTerm policy (afBody f))
+
+lowerCtor :: NamePolicy -> ScalaCtor -> ScalaCtor
+lowerCtor policy (ScalaCtor name args) =
+  ScalaCtor
+    { scName = ctorName policy name
+    , scArgs = args
+    }
+
+lowerField :: NamePolicy -> SeVar -> SeVar
+lowerField policy (SeVar name ty) =
+  SeVar (termName policy name) ty
+
+lowerTerm :: NamePolicy -> ScalaTerm -> ScalaTerm
+lowerTerm policy =
+  \case
+    STeVar name ->
+      STeVar (termName policy name)
+
+    STeApp f args ->
+      STeApp (lowerTerm policy f) (map (lowerTerm policy) args)
+
+    STeLam names body ->
+      STeLam (map (termName policy) names) (lowerTerm policy body)
+
+    STeLitInt n ->
+      STeLitInt n
+
+    STeLitBool b ->
+      STeLitBool b
+
+    STeLitString s ->
+      STeLitString s
+
+    STeError err ->
+      STeError err

--- a/test/HedgehogMain.hs
+++ b/test/HedgehogMain.hs
@@ -5,6 +5,7 @@ import Hedgehog (Group, checkParallel)
 import qualified NameEnvProps
 import qualified NamePolicyProps
 import qualified PrintProps
+import qualified IRToScalaProps
 
 main :: IO ()
 main = do
@@ -12,7 +13,8 @@ main = do
     ok2 <- checkParallel PrintProps.tests
     ok3 <- checkParallel AgdaToScalaExprProps.tests
     ok4 <- checkGroups NamePolicyProps.tests
-    if ok1 && ok2 && ok3 && ok4 then pure () else fail "Hedgehog tests failed"
+    ok5 <- checkParallel IRToScalaProps.tests
+    if ok1 && ok2 && ok3 && ok4 && ok5 then pure () else fail "Hedgehog tests failed"
 
 checkGroups :: [Group] -> IO Bool
 checkGroups = fmap and . traverse checkParallel

--- a/test/IRToScalaProps.hs
+++ b/test/IRToScalaProps.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module IRToScalaProps (tests) where
+
+import Hedgehog
+  ( Group(..)
+  , Property
+  , annotateShow
+  , assert
+  , forAll
+  , property
+  , (===)
+  )
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import Agda.Compiler.Scala.IR.Agda
+  ( AgdaData(..)
+  , AgdaDecl(..)
+  , AgdaRecord(..)
+  )
+import Agda.Compiler.Scala.Lower.IRToScala ( toScalaExpr )
+import Agda.Compiler.Scala.NamePolicy ( defaultNamePolicy )
+import Agda.Compiler.Scala.ScalaExpr
+  ( ScalaCtor(..)
+  , ScalaExpr(..)
+  , ScalaType(..)
+  , SeVar(..)
+  )
+
+tests :: Group
+tests =
+  Group "IRToScala"
+    [ ("data lowering preserves constructor arity", prop_dataCtorArityPreserved)
+    , ("data lowering applies constructor NamePolicy", prop_dataCtorNamePolicy)
+    , ("record lowering preserves field count", prop_recordFieldCountPreserved)
+    ]
+
+prop_dataCtorArityPreserved :: Property
+prop_dataCtorArityPreserved = property $ do
+  arity <- forAll (Gen.int (Range.linear 0 8))
+
+  let ctor =
+        ScalaCtor
+          { scName = "Mk"
+          , scArgs = replicate arity (STyName "A")
+          }
+
+      decl =
+        DData
+          AgdaData
+            { adName = "Box"
+            , adTyParams = ["A"]
+            , adCtors = [ctor]
+            }
+
+  case toScalaExpr defaultNamePolicy decl of
+    SeSum _ _ [ScalaCtor _ args] ->
+      length args === arity
+    other -> do
+      annotateShow other
+      assert False
+
+prop_dataCtorNamePolicy :: Property
+prop_dataCtorNamePolicy = property $ do
+  let decl =
+        DData
+          AgdaData
+            { adName = "List"
+            , adTyParams = ["A"]
+            , adCtors =
+                [ ScalaCtor
+                    { scName = "[]"
+                    , scArgs = []
+                    }
+                ]
+            }
+
+  case toScalaExpr defaultNamePolicy decl of
+    SeSum _ _ [ScalaCtor ctorName _] ->
+      ctorName === "Nil"
+    other -> do
+      annotateShow other
+      assert False
+
+prop_recordFieldCountPreserved :: Property
+prop_recordFieldCountPreserved = property $ do
+  fieldCount <- forAll (Gen.int (Range.linear 0 8))
+
+  let fields =
+        [ SeVar ("x" <> show i) (STyName "A")
+        | i <- [0 .. fieldCount - 1]
+        ]
+
+      decl =
+        DRecord
+          AgdaRecord
+            { arName = "Rec"
+            , arTyParams = []
+            , arFields = fields
+            }
+
+  case toScalaExpr defaultNamePolicy decl of
+    SeProd _ _ vars ->
+      length vars === fieldCount
+    other -> do
+      annotateShow other
+      assert False

--- a/test/PrintProps.hs
+++ b/test/PrintProps.hs
@@ -10,7 +10,7 @@ module PrintProps (tests) where
 
 import Data.List (isInfixOf)
 
-import Hedgehog (Gen (..), Group (..), GroupName (..), Property, PropertyName (..), assert, forAll, property, success, (===))
+import Hedgehog (Gen (..), Group (..), Property, assert, forAll, property, success, (===))
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 

--- a/test/TermsProps.hs
+++ b/test/TermsProps.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module TermsProps (tests) where
+
+import Hedgehog (Group(..), Property, property, forAll, (===))
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import Agda.Compiler.Scala.AgdaToScalaExpr.Terms (compileBodyTerm, Env(..))
+import Agda.Compiler.Scala.ScalaExpr (ScalaTerm(..))
+import Agda.Compiler.Scala.AgdaToScalaExpr.Types (CompileError)
+
+import Agda.Syntax.Common (Arg, defaultArg)
+
+import Agda.Syntax.Internal (Term(..), Elim'(..))
+import Agda.Syntax.Common (Arg(..))
+
+tests :: Group
+tests =
+  Group "Terms / application"
+    [ ("Def with k Apply args compiles to application of arity k", prop_def_apply_arity)
+    ]
+
+mkApply :: Term -> Elim' Term
+mkApply t = Apply (defaultArg t)
+
+prop_def_apply_arity :: Property
+prop_def_apply_arity = property $ do
+  k <- forAll (Gen.int (Range.linear 0 5))
+
+  let env = Env ["x0"]
+      let elims = replicate k (mkApply (Var 0 []))
+          t     = Var 0 elims
+
+  case compileBodyTerm env t of
+    Left _ -> do
+      -- acceptable only if k==0 and variable resolves; otherwise fail
+      k === 0
+    Right tm ->
+      case tm of
+        STeVar _       -> k === 0
+        STeApp _ args  -> length args === k
+        _              -> False === True


### PR DESCRIPTION
Split ADT representing expressions into ScalIR and AgdaIR

Add properties:
- Data lowering preserves constructor arity
- data lowering applies constructor NamePolicy
- record lowering preserves field count