### PR TITLE
`lookup` in `RedBlackTree` - support if then else and binary operators

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -65,12 +65,14 @@ jobs:
         run: cabal test all
 
       - name: Compile example Agda code to Scala 2
-        run: cabal run -- agda2scala --scala-dialect=Scala2 --out-dir=scala2/src/main/scala ./examples/adts.agda
-        run: cabal run -- agda2scala --scala-dialect=Scala2 --out-dir=scala2/src/main/scala ./examples/rbt.agda
+        run: |
+          cabal run -- agda2scala --scala-dialect=Scala2 --out-dir=scala2/src/main/scala ./examples/adts.agda
+          cabal run -- agda2scala --scala-dialect=Scala2 --out-dir=scala2/src/main/scala ./examples/rbt.agda
 
       - name: Compile example Agda code to Scala 3
-        run: cabal run -- agda2scala --out-dir=scala3/src/main/scala ./examples/adts.agda
-        run: cabal run -- agda2scala --out-dir=scala3/src/main/scala ./examples/rbt.agda
+        run: |
+          cabal run -- agda2scala --out-dir=scala3/src/main/scala ./examples/adts.agda
+          cabal run -- agda2scala --out-dir=scala3/src/main/scala ./examples/rbt.agda
 
       - name: Set up JVM
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -66,9 +66,11 @@ jobs:
 
       - name: Compile example Agda code to Scala 2
         run: cabal run -- agda2scala --scala-dialect=Scala2 --out-dir=scala2/src/main/scala ./examples/adts.agda
+        run: cabal run -- agda2scala --scala-dialect=Scala2 --out-dir=scala2/src/main/scala ./examples/rbt.agda
 
       - name: Compile example Agda code to Scala 3
         run: cabal run -- agda2scala --out-dir=scala3/src/main/scala ./examples/adts.agda
+        run: cabal run -- agda2scala --out-dir=scala3/src/main/scala ./examples/rbt.agda
 
       - name: Set up JVM
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -49,6 +49,15 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: cabal build all --only-dependencies
 
+      - name: Install Agda standard library
+        run: |
+          git clone --depth 1 --branch v2.4 https://github.com/agda/agda-stdlib.git "$HOME/agda-stdlib"
+          mkdir -p "$HOME/.config/agda"
+          echo "$HOME/agda-stdlib/standard-library.agda-lib" > "$HOME/.config/agda/libraries"
+          echo "standard-library" > "$HOME/.config/agda/defaults"
+          cat "$HOME/.config/agda/libraries"
+          cat "$HOME/.config/agda/defaults"
+
       # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
       - name: Save cached dependencies
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ See [Agda.Compiler.Scala.Name.NamePolicy](./src/Agda/Compiler/Scala/NamePolicy.h
 
 ```shell
 find -name '*.hs' | entr cabal test all
+find . -name '*.hs' | entr cabal test agda2scala-test
+find . -name '*.hs' | entr cabal test agda2scala-props
 ```
 
 or using [ghcid](https://hackage.haskell.org/package/ghcid)
@@ -179,7 +181,8 @@ Those tests are [run on CI - Github Actions](/.github/workflows/haskell.yml).
 
 Generate Scala 2 code from Agda examples and running tests:
 ```shell
-cabal run -- agda2scala --compile --no-main --out-dir=scala2/src/main/scala ./examples/adts.agda
+cabal run -- agda2scala --compile --no-main --scala-dialect=Scala2 --out-dir=scala2/src/main/scala ./examples/adts.agda
+cabal run -- agda2scala --compile --no-main --scala-dialect=Scala2 --out-dir=scala2/src/main/scala ./examples/rbt.agda
 cd scala2
 sbt ~test
 ```
@@ -187,6 +190,7 @@ sbt ~test
 generate Scala 3 code:
 ```shell
 cabal run -- agda2scala --compile --no-main --scala-dialect=Scala3 --out-dir=scala3/src/main/scala ./examples/adts.agda
+cabal run -- agda2scala --compile --no-main --scala-dialect=Scala3 --out-dir=scala3/src/main/scala ./examples/rbt.agda
 cd scala3
 sbt ~test
 ```

--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -103,6 +103,7 @@ test-suite agda2scala-test
     Compile.TypesTest
     Name.NameEnvTest
     Name.NamePolicyTest
+    Render.CommonTest
     Render.PrintScala2Test
     Render.PrintScala3Test
     ScalaBackendTest

--- a/examples/rbt.agda
+++ b/examples/rbt.agda
@@ -1,0 +1,28 @@
+module examples.rbt where
+
+open import Data.Bool using (Bool; true; false; if_then_else_)
+open import Data.Nat using (ℕ; _<ᵇ_)
+
+data Color : Set where
+  Red Black : Color
+{-# COMPILE AGDA2SCALA Color #-}
+
+data RedBlackTree (V : Set) : Set where
+  EmptyRBT : RedBlackTree V
+  RBT      : Color -> RedBlackTree V -> ℕ -> V -> RedBlackTree V -> RedBlackTree V
+{-# COMPILE AGDA2SCALA RedBlackTree #-}
+
+lookup : {V : Set} -> V -> ℕ -> RedBlackTree V -> V
+lookup defaultVal key EmptyRBT =
+  defaultVal
+
+lookup defaultVal key (RBT c left currKey x right) =
+  if key <ᵇ currKey then
+    lookup defaultVal key left
+  else
+    if currKey <ᵇ key then
+      lookup defaultVal key right
+    else
+      x
+
+{-# COMPILE AGDA2SCALA lookup #-}

--- a/examples/rbt.agda
+++ b/examples/rbt.agda
@@ -15,7 +15,6 @@ data RedBlackTree (V : Set) : Set where
 lookup : {V : Set} -> V -> ℕ -> RedBlackTree V -> V
 lookup defaultVal key EmptyRBT =
   defaultVal
-
 lookup defaultVal key (RBT c left currKey x right) =
   if key <ᵇ currKey then
     lookup defaultVal key left
@@ -24,5 +23,4 @@ lookup defaultVal key (RBT c left currKey x right) =
       lookup defaultVal key right
     else
       x
-
 {-# COMPILE AGDA2SCALA lookup #-}

--- a/scala2/src/main/scala/examples/adts.scala
+++ b/scala2/src/main/scala/examples/adts.scala
@@ -8,21 +8,18 @@ object Rgb {
   case object Red extends Rgb
   case object Green extends Rgb
   case object Blue extends Rgb
-
 }
 
 sealed trait Answer
 object Answer {
   case object Yes extends Answer
   case object No extends Answer
-
 }
 
 sealed trait Color
 object Color {
   final case class Light(x0: Rgb) extends Color
   final case class Dark(x0: Rgb) extends Color
-
 }
 
 final case class RgbPair(fst: Rgb, snd: Answer)
@@ -43,23 +40,25 @@ sealed trait Maybe[A]
 object Maybe {
   final case class Just[A](x0: A) extends Maybe[A]
   case object None extends Maybe[Nothing]
-
 }
 
 sealed trait List[X]
 object List {
   case object Nil extends List[Nothing]
   final case class Cons[X](x0: X, x1: List[X]) extends List[X]
-
 }
 
 def not(x0: Answer): Answer = x0 match {
-  case Answer.Yes => Answer.No
-  case Answer.No => Answer.Yes
+  case Answer.Yes =>
+    Answer.No
+  case Answer.No =>
+    Answer.Yes
 }
 
 def unColor(x0: Color): Rgb = x0 match {
-  case Color.Light(p0) => p0
-  case Color.Dark(p0) => p0
+  case Color.Light(p0) =>
+    p0
+  case Color.Dark(p0) =>
+    p0
 }
 }

--- a/scala2/src/main/scala/examples/rbt.scala
+++ b/scala2/src/main/scala/examples/rbt.scala
@@ -1,0 +1,24 @@
+package examples
+
+object rbt
+{
+
+sealed trait Color
+object Color {
+  case object Red extends Color
+  case object Black extends Color
+
+}
+
+sealed trait RedBlackTree[V]
+object RedBlackTree {
+  case object EmptyRBT extends RedBlackTree[Nothing]
+  final case class RBT[V](x0: Color, x1: RedBlackTree[V], x2: Long, x3: V, x4: RedBlackTree[V]) extends RedBlackTree[V]
+
+}
+
+def lookup[V](x1: V, x2: Long, x3: RedBlackTree[V]): V = x3 match {
+  case RedBlackTree.EmptyRBT => x1
+  case RedBlackTree.RBT(p0, p1, p2, p3, p4) => if (x2 < p2) lookup(x1, x2, p1) else if (p2 < x2) lookup(x1, x2, p4) else p3
+}
+}

--- a/scala2/src/main/scala/examples/rbt.scala
+++ b/scala2/src/main/scala/examples/rbt.scala
@@ -7,18 +7,23 @@ sealed trait Color
 object Color {
   case object Red extends Color
   case object Black extends Color
-
 }
 
 sealed trait RedBlackTree[V]
 object RedBlackTree {
   case object EmptyRBT extends RedBlackTree[Nothing]
   final case class RBT[V](x0: Color, x1: RedBlackTree[V], x2: Long, x3: V, x4: RedBlackTree[V]) extends RedBlackTree[V]
-
 }
 
 def lookup[V](x1: V, x2: Long, x3: RedBlackTree[V]): V = x3 match {
-  case RedBlackTree.EmptyRBT => x1
-  case RedBlackTree.RBT(p0, p1, p2, p3, p4) => if (x2 < p2) lookup(x1, x2, p1) else if (p2 < x2) lookup(x1, x2, p4) else p3
+  case RedBlackTree.EmptyRBT =>
+    x1
+  case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+    if (x2 < p2)
+      lookup(x1, x2, p1)
+    else if (p2 < x2)
+      lookup(x1, x2, p4)
+    else
+      p3
 }
 }

--- a/scala2/src/test/scala/examples/RedBlackTreeSpec.scala
+++ b/scala2/src/test/scala/examples/RedBlackTreeSpec.scala
@@ -1,0 +1,38 @@
+package examples
+
+import zio.test.junit.JUnitRunnableSpec
+import zio.test.assertTrue
+
+import examples.rbt.RedBlackTree
+import examples.rbt.Color
+import examples.rbt.RedBlackTree.EmptyRBT
+import examples.rbt.lookup
+
+object RedBlackTreeSpec extends JUnitRunnableSpec {
+
+  // temporary until generated RedBlackTree is covariant
+  // https://github.com/dancewithheart/agda2scala/issues/26
+  private def emptyRBT[V]: RedBlackTree[V] =
+    EmptyRBT.asInstanceOf[RedBlackTree[V]]
+
+  def spec = suite("RedBlackTree")(
+    test("lookup on empty rbt returns default value") {
+      val rbt = emptyRBT[String]
+      val defaultVal = "foo"
+      val key = 42L
+      assertTrue(defaultVal == lookup(defaultVal, key, rbt))
+    },
+    test("lookup returns stored value when key matches root") {
+      val rbt =
+        RedBlackTree.RBT[String](
+          Color.Black,
+          emptyRBT[String],
+          42L,
+          "found",
+          emptyRBT[String]
+        )
+
+      assertTrue(lookup("default", 42L, rbt) == "found")
+    }
+  )
+}

--- a/scala2/src/test/scala/examples/RgbSpec.scala
+++ b/scala2/src/test/scala/examples/RgbSpec.scala
@@ -11,7 +11,7 @@ import examples.adts.Answer.{Yes, No}
 
 object RgbSpec extends JUnitRunnableSpec {
 
-  def spec = suite("Examples test")(
+  def spec = suite("RGB")(
     test("identity on Rgb") {
       assert(idRgb(Red))(equalTo(Red)) &&
       assert(idRgb(Green))(equalTo(Green)) &&

--- a/scala3/src/main/scala/examples/adts.scala
+++ b/scala3/src/main/scala/examples/adts.scala
@@ -37,9 +37,13 @@ object adts:
     case Cons[X](x0: X, x1: List[X]) extends List[X]
 
   def not(x0: Answer): Answer = x0 match
-    case Answer.Yes => Answer.No
-    case Answer.No => Answer.Yes
+    case Answer.Yes =>
+      Answer.No
+    case Answer.No =>
+      Answer.Yes
 
   def unColor(x0: Color): Rgb = x0 match
-    case Color.Light(p0) => p0
-    case Color.Dark(p0) => p0
+    case Color.Light(p0) =>
+      p0
+    case Color.Dark(p0) =>
+      p0

--- a/scala3/src/main/scala/examples/rbt.scala
+++ b/scala3/src/main/scala/examples/rbt.scala
@@ -1,0 +1,14 @@
+package examples
+
+object rbt:
+  enum Color:
+    case Red
+    case Black
+
+  enum RedBlackTree[V]:
+    case EmptyRBT extends RedBlackTree[Nothing]
+    case RBT[V](x0: Color, x1: RedBlackTree[V], x2: Long, x3: V, x4: RedBlackTree[V]) extends RedBlackTree[V]
+
+  def lookup[V](x1: V, x2: Long, x3: RedBlackTree[V]): V = x3 match
+    case RedBlackTree.EmptyRBT => x1
+    case RedBlackTree.RBT(p0, p1, p2, p3, p4) => if (x2 < p2) lookup(x1, x2, p1) else if (p2 < x2) lookup(x1, x2, p4) else p3

--- a/scala3/src/main/scala/examples/rbt.scala
+++ b/scala3/src/main/scala/examples/rbt.scala
@@ -10,5 +10,12 @@ object rbt:
     case RBT[V](x0: Color, x1: RedBlackTree[V], x2: Long, x3: V, x4: RedBlackTree[V]) extends RedBlackTree[V]
 
   def lookup[V](x1: V, x2: Long, x3: RedBlackTree[V]): V = x3 match
-    case RedBlackTree.EmptyRBT => x1
-    case RedBlackTree.RBT(p0, p1, p2, p3, p4) => if (x2 < p2) lookup(x1, x2, p1) else if (p2 < x2) lookup(x1, x2, p4) else p3
+    case RedBlackTree.EmptyRBT =>
+      x1
+    case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+      if x2 < p2 then
+        lookup(x1, x2, p1)
+      else if p2 < x2 then
+        lookup(x1, x2, p4)
+      else
+        p3

--- a/scala3/src/test/scala/examples/RedBlackTreeSpec.scala
+++ b/scala3/src/test/scala/examples/RedBlackTreeSpec.scala
@@ -1,0 +1,36 @@
+package examples
+
+import zio.test.junit.JUnitRunnableSpec
+import zio.test.assertTrue
+
+import examples.rbt.RedBlackTree
+import examples.rbt.Color
+import examples.rbt.RedBlackTree.EmptyRBT
+import examples.rbt.lookup
+
+object RedBlackTreeSpec extends JUnitRunnableSpec:
+
+  // temporary until generated RedBlackTree is covariant
+  // https://github.com/dancewithheart/agda2scala/issues/26
+  private def emptyRBT[V]: RedBlackTree[V] =
+    EmptyRBT.asInstanceOf[RedBlackTree[V]]
+
+  def spec = suite("Test Rgb")(
+    test("lookup on empty rbt returns default value") {
+      val rbt = emptyRBT[String]
+      val defaultVal = "foo"
+      val key = 42L
+      assertTrue(defaultVal == lookup(defaultVal, key, rbt))
+    },
+    test("lookup returns stored value when key matches root") {
+      val rbt =
+        RedBlackTree.RBT[String](
+          Color.Black,
+          emptyRBT[String],
+          42L,
+          "found",
+          emptyRBT[String]
+        )
+      assertTrue(lookup("default", 42L, rbt) == "found")
+    }
+  )

--- a/src/Agda/Compiler/Scala/Backend.hs
+++ b/src/Agda/Compiler/Scala/Backend.hs
@@ -112,7 +112,7 @@ scalaCmdLineFlags =
         ['b']
         ["scala-dialect"]
         (ReqArg scalaDialectOpt "scalaDialect")
-        "Write output files using Scala2 or Scala3 dialect. (default: Scala2)"
+        "Write output files using Scala2 or Scala3 dialect. (default: Scala3)"
     ]
 
 outDirOpt :: (Monad m) => FilePath -> Options -> m Options
@@ -173,6 +173,10 @@ qualifyTermWithEnv ne = go
       Nothing -> STeVar n
     go (STeApp f xs)    = STeApp (go f) (map go xs)
     go (STeLam ns body) = STeLam ns (go body)
+    go (STeIf cond thenBranch elseBranch) =
+      STeIf (go cond) (go thenBranch) (go elseBranch)
+    go (STeBinOp lhs op rhs) =
+      STeBinOp (go lhs) op (go rhs)
     go (STeLitInt i)    = STeLitInt i
     go (STeLitBool b)   = STeLitBool b
     go (STeLitString s) = STeLitString s

--- a/src/Agda/Compiler/Scala/Compile/Terms.hs
+++ b/src/Agda/Compiler/Scala/Compile/Terms.hs
@@ -13,7 +13,7 @@ module Agda.Compiler.Scala.Compile.Terms
 ) where
 
 import Data.Maybe (catMaybes, fromMaybe, isJust)
-import Debug.Trace (trace)
+--import Debug.Trace (trace) -- TODO #72
 import qualified Data.Map as Map
 import Agda.Syntax.Abstract.Name ( QName )
 import Agda.Syntax.Common
@@ -80,15 +80,18 @@ extendEnv :: [ScalaName] -> Env -> Env
 extendEnv names (Env xs) = Env (map Just (reverse names) <> xs)
 
 lookupVar :: Env -> Int -> Either CompileError ScalaName
-lookupVar env@(Env xs) i = case drop i xs of
+-- lookupVar env@(Env xs) i = case drop i xs of -- #72
+lookupVar (Env xs) i = case drop i xs of
   Just name : _ -> Right name
-  Nothing : _ -> trace
-     ( "ErasedVarReferenced "
-       <> show i
-       <> " in env "
-       <> show env
-     )
-     (Left (ErasedVarReferenced i))
+  Nothing : _ -> Left (ErasedVarReferenced i)
+-- -- TODO restore and hide behing a flag https://github.com/dancewithheart/agda2scala/issues/72
+--    trace
+--     ( "ErasedVarReferenced "
+--       <> show i
+--       <> " in env "
+--       <> show env
+--     )
+--     (Left (ErasedVarReferenced i))
   [] -> Left (VarOutOfRange i (length xs))
 
 -- Agda uses two index conventions here.
@@ -211,7 +214,7 @@ compileVisibleElim env elim = case elim of
 
 compileConApp :: Env -> ConHead -> [Elim' Term] -> Either CompileError ScalaTerm
 compileConApp env conHead elims = do
-    args <- fmap catMaybes (traverse (compileElimMaybe env) elims)
+    args <- compileVisibleApplyTerms env elims
     let f = STeVar (ctorName defaultNamePolicy (fromQName (conName conHead)))
     pure $ case args of
         [] -> f
@@ -223,14 +226,6 @@ applyElims env f elims = do
   pure $ case args of
     [] -> f
     _  -> STeApp f args
-
-compileElimMaybe :: Env -> Elim' Term -> Either CompileError (Maybe ScalaTerm)
-compileElimMaybe env elim = case elim of
-    Apply arg
-      | getHiding arg /= NotHidden -> Right Nothing
-      | isErasedTypeArgument (unArg arg) -> Right Nothing
-      | otherwise -> Just <$> compileBodyTerm env (unArg arg)
-    _ -> Right Nothing
 
 isErasedTypeArgument :: Term -> Bool
 isErasedTypeArgument term = case term of
@@ -245,24 +240,25 @@ compileLiteral = \case
     LitString s -> pure (STeLitString (T.unpack s))
     l -> Left (UnsupportedTerm (Lit l))
 
-debugElims :: String -> [Elim' Term] -> Either CompileError ()
-debugElims label elims =
-    trace
-        ( unlines
-            [ "===== AGDA2SCALA TERMS DEBUG: " <> label <> " ====="
-            , "elim count: " <> show (length elims)
-            , unlines (zipWith showElim [0 :: Int ..] elims)
-            , "===== END TERMS DEBUG ====="
-            ]
-        )
-        (Right ())
-  where
-    showElim i elim =
-        case elim of
-            Apply arg ->
-                show i
-                    <> ": Apply hiding="
-                    <> show (getHiding arg)
-                    <> " term="
-                    <> show (unArg arg)
-            _ -> show i <> ": non-Apply " <> show elim
+-- TODO restore and hide behing a flag #72
+--debugElims :: String -> [Elim' Term] -> Either CompileError ()
+--debugElims label elims =
+--    trace
+--        ( unlines
+--            [ "===== AGDA2SCALA TERMS DEBUG: " <> label <> " ====="
+--            , "elim count: " <> show (length elims)
+--            , unlines (zipWith showElim [0 :: Int ..] elims)
+--            , "===== END TERMS DEBUG ====="
+--            ]
+--        )
+--        (Right ())
+--  where
+--    showElim i elim =
+--        case elim of
+--            Apply arg ->
+--                show i
+--                    <> ": Apply hiding="
+--                    <> show (getHiding arg)
+--                    <> " term="
+--                    <> show (unArg arg)
+--            _ -> show i <> ": non-Apply " <> show elim

--- a/src/Agda/Compiler/Scala/Compile/Terms.hs
+++ b/src/Agda/Compiler/Scala/Compile/Terms.hs
@@ -11,7 +11,12 @@ module Agda.Compiler.Scala.Compile.Terms (
 
 import Data.Maybe (catMaybes, fromMaybe, isJust)
 import qualified Data.Map as Map
-import Agda.Syntax.Common (Arg (..))
+import Agda.Syntax.Abstract.Name ( QName )
+import Agda.Syntax.Common
+  ( Arg(..)
+  , Hiding(..)
+  , getHiding
+  )
 import Agda.Syntax.Internal (ConHead (..), Elim' (..), Term (..))
 import Agda.Syntax.Literal (Literal (..))
 import Agda.TypeChecking.CompiledClause
@@ -26,7 +31,7 @@ import Agda.Compiler.Scala.Compile.Types
   ( CompileError (..)
   , CaseUnsupported (..)
   , fromQName)
-import Agda.Compiler.Scala.Name.NamePolicy (ctorName, defaultNamePolicy)
+import Agda.Compiler.Scala.Name.NamePolicy (ctorName, defaultNamePolicy, termName)
 import Agda.Compiler.Scala.IR.ScalaExpr
   ( ScalaName
   , ScalaPat(..)
@@ -76,6 +81,8 @@ lookupVar (Env xs) i = case drop i xs of
 
 -- ===== Function bodies =======================================================
 
+-- Function bodies are read from `CompiledClauses`, not from surface syntax.
+-- Pattern matching therefore appears as Agda's compiled case tree.
 compileFunctionBody :: [ScalaName] -> Maybe CompiledClauses -> Either CompileError ScalaTerm
 compileFunctionBody _ Nothing       = Left UnsupportedCompiledClauses
 compileFunctionBody argNs (Just cc) = compileCompiledClauses (envFromArgs argNs) cc
@@ -101,6 +108,8 @@ compileBranches env branches = do
       rhs <- compileCompiledClauses env' cc
       pure (pat, rhs)
 
+-- Reject unsupported case-tree shapes explicitly.
+-- Silent branch dropping would generate partial Scala matches.
 validateCaseShape :: Case CompiledClauses -> Either CompileError ()
 validateCaseShape branches
     | projPatterns branches                  = Left $ UnsupportedCaseShape HasProjectionPatterns
@@ -116,12 +125,43 @@ compileBodyTerm env = \case
     Var i elims -> do
         f <- STeVar <$> lookupVar env i
         applyElims env f elims
-    Def qn elims -> do
-        let f = STeVar (fromQName qn)
-        applyElims env f elims
+    Def qn elims
+      | fromQName qn == "if_then_else_" ->compileIfThenElse env qn elims
+      | fromQName qn == "_<ᵇ_" -> compileBinaryOp env qn "<" elims
+      | fromQName qn == "_<_" -> compileBinaryOp env qn "<" elims
+      | otherwise -> do
+          let f = STeVar (termName defaultNamePolicy (fromQName qn))
+          applyElims env f elims
     Con ch _ es -> compileConApp env ch es
     Lit lit -> compileLiteral lit
     t -> Left (UnsupportedTerm t)
+
+compileIfThenElse :: Env -> QName -> [Elim' Term] -> Either CompileError ScalaTerm
+compileIfThenElse env qn elims =
+  case visibleApplyTerms elims of
+    [cond, thenBranch, elseBranch] ->
+      STeIf
+        <$> compileBodyTerm env cond
+        <*> compileBodyTerm env thenBranch
+        <*> compileBodyTerm env elseBranch
+    _ -> Left (UnsupportedTerm (Def qn elims))
+
+compileBinaryOp :: Env -> QName -> ScalaName -> [Elim' Term] -> Either CompileError ScalaTerm
+compileBinaryOp env qn op elims =
+  case visibleApplyTerms elims of
+    [lhs, rhs] ->
+      STeBinOp
+        <$> compileBodyTerm env lhs
+        <*> pure op
+        <*> compileBodyTerm env rhs
+    _ -> Left (UnsupportedTerm (Def qn elims))
+
+visibleApplyTerms :: [Elim' Term] -> [Term]
+visibleApplyTerms elims =
+  [ unArg arg
+  | Apply arg <- elims
+  , getHiding arg == NotHidden
+  ]
 
 compileConApp :: Env -> ConHead -> [Elim' Term] -> Either CompileError ScalaTerm
 compileConApp env conHead elims = do
@@ -133,20 +173,24 @@ compileConApp env conHead elims = do
 
 applyElims :: Env -> ScalaTerm -> [Elim' Term] -> Either CompileError ScalaTerm
 applyElims env f elims = do
-    args <- fmap catMaybes (traverse (compileElimMaybe env) elims)
-    pure $ case args of
-        [] -> f
-        _  -> STeApp f args
+  args <- fmap catMaybes (traverse (compileElimMaybe env) elims)
+  pure $ case args of
+    [] -> f
+    _  -> STeApp f args
 
 compileElimMaybe :: Env -> Elim' Term -> Either CompileError (Maybe ScalaTerm)
-compileElimMaybe env = \case
-    Apply a ->
-        case unArg a of
-            -- erase universe-level artifacts at term level
-            Level _ -> pure Nothing
-            Sort _  -> pure Nothing
-            t       -> Just <$> compileBodyTerm env t
-    _ -> Left (UnsupportedTerm (Var 0 [])) -- Proj/IApply later
+compileElimMaybe env elim = case elim of
+    Apply arg
+      | getHiding arg /= NotHidden -> Right Nothing
+      | isErasedTypeArgument (unArg arg) -> Right Nothing
+      | otherwise -> Just <$> compileBodyTerm env (unArg arg)
+    _ -> Right Nothing
+
+isErasedTypeArgument :: Term -> Bool
+isErasedTypeArgument term = case term of
+  Level{} -> True
+  Sort{}  -> True
+  _       -> False
 
 compileLiteral :: Literal -> Either CompileError ScalaTerm
 compileLiteral = \case

--- a/src/Agda/Compiler/Scala/Compile/Terms.hs
+++ b/src/Agda/Compiler/Scala/Compile/Terms.hs
@@ -1,15 +1,19 @@
 {-# LANGUAGE LambdaCase #-}
 
-module Agda.Compiler.Scala.Compile.Terms (
-    Env (..),
-    envFromArgs,
-    extendEnv,
-    lookupVar,
-    compileFunctionBody,
-    compileBodyTerm,
+module Agda.Compiler.Scala.Compile.Terms
+  ( Env (..)
+  , envFromArgs
+  , envFromFunction
+  , extendEnv
+  , lookupVar
+  , lookupCaseArg
+  , removeCaseArg
+  , compileFunctionBody
+  , compileBodyTerm
 ) where
 
 import Data.Maybe (catMaybes, fromMaybe, isJust)
+import Debug.Trace (trace)
 import qualified Data.Map as Map
 import Agda.Syntax.Abstract.Name ( QName )
 import Agda.Syntax.Common
@@ -52,15 +56,16 @@ import Agda.Compiler.Scala.IR.ScalaExpr
 -- Therefore all places that introduce binders must go through envFromArgs
 -- or extendEnv.
 
-newtype Env = Env {unEnv :: [ScalaName]}
-    deriving (Eq, Show)
+newtype Env = Env { unEnv :: [Maybe ScalaName] }
+  deriving (Eq, Show)
 
 -- Args come in source order; we want env[0] = last binder (de Bruijn 0).
 envFromArgs :: [ScalaName] -> Env
-envFromArgs names = Env (reverse names)
+envFromArgs names = Env (map Just (reverse names))
 
-freshPatVars :: Int -> [ScalaName]
-freshPatVars arityN = [ "p" <> show i | i <- [0 .. arityN - 1] ]
+envFromFunction :: [ScalaName] -> [ScalaName] -> Env
+envFromFunction tyParams argNames =
+  Env (map Just (reverse argNames) <> replicate (length tyParams) Nothing)
 
 -- Agda de Bruijn convention used here:
 -- Env index 0 is the most recently introduced binder.
@@ -72,27 +77,63 @@ freshPatVars arityN = [ "p" <> show i | i <- [0 .. arityN - 1] ]
 --   Var 0 -> p1
 --   Var 1 -> p0
 extendEnv :: [ScalaName] -> Env -> Env
-extendEnv names (Env xs) = Env (reverse names <> xs)
+extendEnv names (Env xs) = Env (map Just (reverse names) <> xs)
 
 lookupVar :: Env -> Int -> Either CompileError ScalaName
-lookupVar (Env xs) i = case drop i xs of
-  v : _ -> Right v
-  []    -> Left (VarOutOfRange i (length xs))
+lookupVar env@(Env xs) i = case drop i xs of
+  Just name : _ -> Right name
+  Nothing : _ -> trace
+     ( "ErasedVarReferenced "
+       <> show i
+       <> " in env "
+       <> show env
+     )
+     (Left (ErasedVarReferenced i))
+  [] -> Left (VarOutOfRange i (length xs))
+
+-- Agda uses two index conventions here.
+--
+--  Var i   uses de Bruijn order: newest binder first.
+--  Case i  uses function-argument order: left-to-right, including erased binders.
+--  Case branch bodies are compiled after removing the scrutinized argument.
+lookupCaseArg :: Env -> Int -> Either CompileError ScalaName
+lookupCaseArg (Env xs) i =
+    case drop i (reverse xs) of
+        Just name : _ -> Right name
+        Nothing : _   -> Left (ErasedVarReferenced i)
+        []            -> Left (VarOutOfRange i (length xs))
+
+-- removes by Case/source-order index, not by de Bruijn index
+removeCaseArg :: Env -> Int -> Either CompileError Env
+removeCaseArg (Env xs) i =
+    case splitAt i (reverse xs) of
+        (before, Just _ : after) ->
+            Right (Env (reverse (before <> after)))
+        (_before, Nothing : _after) ->
+            Left (ErasedVarReferenced i)
+        _ ->
+            Left (VarOutOfRange i (length xs))
 
 -- ===== Function bodies =======================================================
 
 -- Function bodies are read from `CompiledClauses`, not from surface syntax.
 -- Pattern matching therefore appears as Agda's compiled case tree.
-compileFunctionBody :: [ScalaName] -> Maybe CompiledClauses -> Either CompileError ScalaTerm
-compileFunctionBody _ Nothing       = Left UnsupportedCompiledClauses
-compileFunctionBody argNs (Just cc) = compileCompiledClauses (envFromArgs argNs) cc
+compileFunctionBody
+  :: [ScalaName] -- erased type parameters
+  -> [ScalaName] -- runtime term parameters
+  -> Maybe CompiledClauses
+  -> Either CompileError ScalaTerm
+compileFunctionBody _tyParams _argNames Nothing = Left UnsupportedCompiledClauses
+compileFunctionBody tyParams argNames (Just cc) = compileCompiledClauses (envFromFunction tyParams argNames) cc
 
 compileCompiledClauses :: Env -> CompiledClauses -> Either CompileError ScalaTerm
 compileCompiledClauses env = \case
     Done _ term -> compileBodyTerm env term
     Case arg branches -> do
-      scrut <- STeVar <$> lookupVar env (unArg arg)
-      alts <- compileBranches env branches
+      let n = (unArg arg)
+      scrut <- STeVar <$> lookupCaseArg env n
+      branchEnv <- removeCaseArg env n
+      alts <- compileBranches branchEnv branches
       pure (STeMatch scrut alts)
     _ -> Left UnsupportedCompiledClauses
 
@@ -107,6 +148,9 @@ compileBranches env branches = do
           env'    = extendEnv patVars env
       rhs <- compileCompiledClauses env' cc
       pure (pat, rhs)
+
+freshPatVars :: Int -> [ScalaName]
+freshPatVars arityN = [ "p" <> show i | i <- [0 .. arityN - 1] ]
 
 -- Reject unsupported case-tree shapes explicitly.
 -- Silent branch dropping would generate partial Scala matches.
@@ -126,10 +170,11 @@ compileBodyTerm env = \case
         f <- STeVar <$> lookupVar env i
         applyElims env f elims
     Def qn elims
-      | fromQName qn == "if_then_else_" ->compileIfThenElse env qn elims
+      | fromQName qn == "if_then_else_" -> compileIfThenElse env qn elims
       | fromQName qn == "_<ᵇ_" -> compileBinaryOp env qn "<" elims
       | fromQName qn == "_<_" -> compileBinaryOp env qn "<" elims
       | otherwise -> do
+--          debugElims ("Def " <> fromQName qn) elims
           let f = STeVar (termName defaultNamePolicy (fromQName qn))
           applyElims env f elims
     Con ch _ es -> compileConApp env ch es
@@ -137,31 +182,32 @@ compileBodyTerm env = \case
     t -> Left (UnsupportedTerm t)
 
 compileIfThenElse :: Env -> QName -> [Elim' Term] -> Either CompileError ScalaTerm
-compileIfThenElse env qn elims =
-  case visibleApplyTerms elims of
+compileIfThenElse env qn elims = do
+--  debugElims "if_then_else_" elims
+  args <- compileVisibleApplyTerms env elims
+  case args of
     [cond, thenBranch, elseBranch] ->
-      STeIf
-        <$> compileBodyTerm env cond
-        <*> compileBodyTerm env thenBranch
-        <*> compileBodyTerm env elseBranch
+      pure (STeIf cond thenBranch elseBranch)
     _ -> Left (UnsupportedTerm (Def qn elims))
 
 compileBinaryOp :: Env -> QName -> ScalaName -> [Elim' Term] -> Either CompileError ScalaTerm
-compileBinaryOp env qn op elims =
-  case visibleApplyTerms elims of
-    [lhs, rhs] ->
-      STeBinOp
-        <$> compileBodyTerm env lhs
-        <*> pure op
-        <*> compileBodyTerm env rhs
-    _ -> Left (UnsupportedTerm (Def qn elims))
+compileBinaryOp env qn op elims = do
+--    debugElims ("binary op " <> op) elims
+    args <- compileVisibleApplyTerms env elims
+    case args of
+        [lhs, rhs] -> pure (STeBinOp lhs op rhs)
+        _ -> Left (UnsupportedTerm (Def qn elims))
 
-visibleApplyTerms :: [Elim' Term] -> [Term]
-visibleApplyTerms elims =
-  [ unArg arg
-  | Apply arg <- elims
-  , getHiding arg == NotHidden
-  ]
+compileVisibleApplyTerms :: Env -> [Elim' Term] -> Either CompileError [ScalaTerm]
+compileVisibleApplyTerms env elims = fmap catMaybes (traverse (compileVisibleElim env) elims)
+
+compileVisibleElim :: Env -> Elim' Term -> Either CompileError (Maybe ScalaTerm)
+compileVisibleElim env elim = case elim of
+    Apply arg
+      | getHiding arg /= NotHidden -> Right Nothing
+      | isErasedTypeArgument (unArg arg) -> Right Nothing
+      | otherwise -> Just <$> compileBodyTerm env (unArg arg)
+    _ -> Right Nothing
 
 compileConApp :: Env -> ConHead -> [Elim' Term] -> Either CompileError ScalaTerm
 compileConApp env conHead elims = do
@@ -173,7 +219,7 @@ compileConApp env conHead elims = do
 
 applyElims :: Env -> ScalaTerm -> [Elim' Term] -> Either CompileError ScalaTerm
 applyElims env f elims = do
-  args <- fmap catMaybes (traverse (compileElimMaybe env) elims)
+  args <- compileVisibleApplyTerms env elims
   pure $ case args of
     [] -> f
     _  -> STeApp f args
@@ -198,3 +244,25 @@ compileLiteral = \case
     LitWord64 n -> pure (STeLitInt (fromIntegral n))
     LitString s -> pure (STeLitString (T.unpack s))
     l -> Left (UnsupportedTerm (Lit l))
+
+debugElims :: String -> [Elim' Term] -> Either CompileError ()
+debugElims label elims =
+    trace
+        ( unlines
+            [ "===== AGDA2SCALA TERMS DEBUG: " <> label <> " ====="
+            , "elim count: " <> show (length elims)
+            , unlines (zipWith showElim [0 :: Int ..] elims)
+            , "===== END TERMS DEBUG ====="
+            ]
+        )
+        (Right ())
+  where
+    showElim i elim =
+        case elim of
+            Apply arg ->
+                show i
+                    <> ": Apply hiding="
+                    <> show (getHiding arg)
+                    <> " term="
+                    <> show (unArg arg)
+            _ -> show i <> ": non-Apply " <> show elim

--- a/src/Agda/Compiler/Scala/Compile/Types.hs
+++ b/src/Agda/Compiler/Scala/Compile/Types.hs
@@ -59,6 +59,7 @@ data CompileError
   | UnsupportedCompiledClauses
   | UnsupportedCaseShape CaseUnsupported
   | VarOutOfRange Int Int
+  | ErasedVarReferenced Int
   deriving (Eq, Show)
 
 data CaseUnsupported

--- a/src/Agda/Compiler/Scala/IR/ScalaExpr.hs
+++ b/src/Agda/Compiler/Scala/IR/ScalaExpr.hs
@@ -39,15 +39,17 @@ data ScalaPat
     deriving (Eq, Show)
 
 data ScalaTerm
-    = STeVar ScalaName
-    | STeApp ScalaTerm [ScalaTerm]
-    | STeLam [ScalaName] ScalaTerm
-    | STeMatch ScalaTerm [(ScalaPat, ScalaTerm)]
-    | STeLitInt Int
-    | STeLitBool Bool
-    | STeLitString String
-    | STeError String
-    deriving (Eq, Show)
+  = STeVar ScalaName
+  | STeApp ScalaTerm [ScalaTerm]
+  | STeLam [ScalaName] ScalaTerm
+  | STeMatch ScalaTerm [(ScalaPat, ScalaTerm)]
+  | STeIf ScalaTerm ScalaTerm ScalaTerm
+  | STeBinOp ScalaTerm ScalaName ScalaTerm
+  | STeLitInt Int
+  | STeLitBool Bool
+  | STeLitString String
+  | STeError String
+  deriving (Eq, Show)
 
 data SeVar = SeVar ScalaName ScalaType
     deriving (Eq, Show)

--- a/src/Agda/Compiler/Scala/Lower/AgdaToIR.hs
+++ b/src/Agda/Compiler/Scala/Lower/AgdaToIR.hs
@@ -54,6 +54,7 @@ import Agda.Compiler.Scala.IR.AgdaIR
 import Agda.Compiler.Scala.IR.ScalaExpr
   ( ScalaCtor(..)
   , ScalaName
+  , ScalaTypeScheme(..)
   , SeVar(..)
   )
 
@@ -144,7 +145,7 @@ lowerFun
   -> Either CompileError AgdaFun
 lowerFun qn defTy mcc = do
   (args, scheme) <- funSchemeFromType defTy
-  body <- compileFunctionBody (argNames args) mcc
+  body <- compileFunctionBody (ssTyParams scheme) (argNames args) mcc
   pure
     AgdaFun
       { afName = fromQName qn

--- a/src/Agda/Compiler/Scala/Lower/AgdaToIR.hs
+++ b/src/Agda/Compiler/Scala/Lower/AgdaToIR.hs
@@ -1,7 +1,14 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
 
--- handle interactions with Agda internals
+-- Handle interactions with Agda internals.
+--
+-- Agda backend boundary.
+--
+-- At this point Agda has already parsed, scope-checked, and type-checked
+-- the source module. We inspect checked `Definition`s and lower only the
+-- subset currently supported by agda2scala.
+
 module Agda.Compiler.Scala.Lower.AgdaToIR
   ( toAgdaExpr
   ) where
@@ -50,6 +57,7 @@ import Agda.Compiler.Scala.IR.ScalaExpr
   , SeVar(..)
   )
 
+-- `Definition` is Agda's checked top-level definition
 toAgdaExpr :: Definition -> CompilerPragma -> TCM (Either CompileError AgdaDecl)
 toAgdaExpr def _pragma = case def of
   -- https://hackage-content.haskell.org/package/Agda/docs/Agda-TypeChecking-Monad-Base.html#v:Datatype
@@ -87,7 +95,7 @@ lowerField tyEnv (i, dom) = do
 -- Agda.Syntax.Internal.Tele / Telescope:
 -- https://hackage.haskell.org/package/Agda/docs/Agda-Syntax-Internal.html#t:Tele
 --
--- Telescope is linked, not a normal Haskell list.
+-- Telescopes are linked through `ExtendTel`, not a normal Haskell list.
 teleToList :: Telescope -> [Dom Type]
 teleToList = \case
   EmptyTel           -> []

--- a/src/Agda/Compiler/Scala/Lower/IRToScala.hs
+++ b/src/Agda/Compiler/Scala/Lower/IRToScala.hs
@@ -65,6 +65,17 @@ lowerTerm policy term = case term of
     STeLitBool b        -> STeLitBool b
     STeLitString s      -> STeLitString s
     STeError err        -> STeError err
+    STeIf cond thenBranch elseBranch ->
+      STeIf
+        (lowerTerm policy cond)
+        (lowerTerm policy thenBranch)
+        (lowerTerm policy elseBranch)
+
+    STeBinOp lhs op rhs ->
+      STeBinOp
+        (lowerTerm policy lhs)
+        op
+        (lowerTerm policy rhs)
     STeMatch scrut alts ->
       STeMatch
         (lowerTerm policy scrut)

--- a/src/Agda/Compiler/Scala/Render/Common.hs
+++ b/src/Agda/Compiler/Scala/Render/Common.hs
@@ -9,6 +9,7 @@ module Agda.Compiler.Scala.Render.Common
   , printPat
   , printType
   , printTyParams
+  , sp
   , strip
   ) where
 
@@ -78,6 +79,9 @@ strip = dropWhileEnd (== '\n')
 
 nl :: String
 nl = "\n"
+
+sp :: String
+sp = " "
 
 combineLines :: [String] -> String
 combineLines xs = strip (unlines (filter (not . null) xs))

--- a/src/Agda/Compiler/Scala/Render/Common.hs
+++ b/src/Agda/Compiler/Scala/Render/Common.hs
@@ -84,7 +84,7 @@ sp :: String
 sp = " "
 
 combineLines :: [String] -> String
-combineLines xs = strip (unlines (filter (not . null) xs))
+combineLines = intercalate nl . filter (not . null)
 
 asBottom :: [ScalaName] -> [ScalaName]
 asBottom ps = replicate (length ps) "Nothing"

--- a/src/Agda/Compiler/Scala/Render/Common.hs
+++ b/src/Agda/Compiler/Scala/Render/Common.hs
@@ -1,11 +1,18 @@
 module Agda.Compiler.Scala.Render.Common
   ( escapeScalaString
+  , asBottom
+  , colonSeparator
+  , multiLineCommentBeg
+  , multiLineCommentEnd
+  , nl
+  , combineLines
   , printPat
   , printType
   , printTyParams
+  , strip
   ) where
 
-import Data.List (intercalate)
+import Data.List (dropWhileEnd, intercalate)
 
 import Agda.Compiler.Scala.IR.ScalaExpr
   ( ScalaName
@@ -58,3 +65,22 @@ printPat pat =
     SPLitInt n       -> show n
     SPLitBool b      -> if b then "true" else "false"
     SPLitString s    -> "\"" <> escapeScalaString s <> "\""
+
+colonSeparator :: String
+colonSeparator = ":"
+
+multiLineCommentBeg, multiLineCommentEnd :: String
+multiLineCommentBeg = "/*"
+multiLineCommentEnd = "*/"
+
+strip :: String -> String
+strip = dropWhileEnd (== '\n')
+
+nl :: String
+nl = "\n"
+
+combineLines :: [String] -> String
+combineLines xs = strip (unlines (filter (not . null) xs))
+
+asBottom :: [ScalaName] -> [ScalaName]
+asBottom ps = replicate (length ps) "Nothing"

--- a/src/Agda/Compiler/Scala/Render/PrintScala2.hs
+++ b/src/Agda/Compiler/Scala/Render/PrintScala2.hs
@@ -122,6 +122,12 @@ printTerm x = case x of
         printTerm f <> "(" <> intercalate ", " (map printTerm xs) <> ")"
     STeLam names body ->
         "(" <> intercalate ", " names <> ")" <> sp <> "=>" <> sp <> printTerm body
+    STeIf cond thenBranch elseBranch ->
+      "if" <> sp <> "(" <> printTerm cond <> ")" <> sp
+        <> printTerm thenBranch
+        <> sp <> "else" <> sp
+        <> printTerm elseBranch
+    STeBinOp lhs op rhs -> printTerm lhs <> sp <> op <> sp <> printTerm rhs
     STeLitInt n -> show n
     STeLitBool b -> if b then "true" else "false" -- Scala lowercase
     STeLitString s -> "\"" <> escapeScalaString s <> "\""

--- a/src/Agda/Compiler/Scala/Render/PrintScala2.hs
+++ b/src/Agda/Compiler/Scala/Render/PrintScala2.hs
@@ -6,7 +6,7 @@ module Agda.Compiler.Scala.Render.PrintScala2 (
     printCaseClass,
     printSum,
     printType,
-    combineLines
+    combineDecls
 ) where
 
 import Data.List (intercalate)
@@ -40,7 +40,7 @@ printScala2 def = case def of
         printPackageAndObject pNames
             <> nl
             <> bracket
-                (nl <> combineLines (map printScala2 defs))
+                (nl <> combineDecls (map printScala2 defs))
             <> nl
     SeSum name tyParams ctors ->
         printSum name tyParams ctors
@@ -208,3 +208,11 @@ printCompanionObject name ctorLines =
 
 indentBlock :: Int -> String -> String
 indentBlock n = intercalate "\n" . map (replicate n ' ' <>) . lines
+
+combineDecls :: [String] -> String
+combineDecls =
+    intercalate (nl <> nl) . filter (not . null) . map stripTrailingNewlines
+
+stripTrailingNewlines :: String -> String
+stripTrailingNewlines =
+    reverse . dropWhile (== '\n') . reverse

--- a/src/Agda/Compiler/Scala/Render/PrintScala2.hs
+++ b/src/Agda/Compiler/Scala/Render/PrintScala2.hs
@@ -21,6 +21,7 @@ import Agda.Compiler.Scala.Render.Common
   , printPat
   , printType
   , printTyParams
+  , sp
   )
 import Agda.Compiler.Scala.IR.ScalaExpr (
     ScalaCtor (..),
@@ -125,30 +126,50 @@ printCaseClass name tyParams args =
 -- ===== Terms ================================================================
 
 printTerm :: ScalaTerm -> String
-printTerm x = case x of
+printTerm = printTermBlock
+
+printTermInline :: ScalaTerm -> String
+printTermInline term =
+    case term of
+        STeIf{} -> "(" <> printTermBlock term <> ")"
+        STeMatch{} -> "(" <> printTermBlock term <> ")"
+        _ -> printTermBlock term
+
+printTermBlock :: ScalaTerm -> String
+printTermBlock x = case x of
     STeVar n -> n
-    STeApp f xs ->
-        printTerm f <> "(" <> intercalate ", " (map printTerm xs) <> ")"
-    STeLam names body ->
-        "(" <> intercalate ", " names <> ")" <> sp <> "=>" <> sp <> printTerm body
-    STeIf cond thenBranch elseBranch ->
-      "if" <> sp <> "(" <> printTerm cond <> ")" <> sp
-        <> printTerm thenBranch
-        <> sp <> "else" <> sp
-        <> printTerm elseBranch
-    STeBinOp lhs op rhs -> printTerm lhs <> sp <> op <> sp <> printTerm rhs
+    STeApp f xs -> printTermInline f <> "(" <> intercalate ", " (map printTermInline xs) <> ")"
+    STeLam names body -> "(" <> intercalate ", " names <> ")" <> sp <> "=>" <> sp <> printTermInline body
     STeLitInt n -> show n
-    STeLitBool b -> if b then "true" else "false" -- Scala lowercase
+    STeLitBool b -> if b then "true" else "false"
     STeLitString s -> "\"" <> escapeScalaString s <> "\""
+    STeIf cond thenBranch elseBranch -> printIf cond thenBranch elseBranch
+    STeBinOp lhs op rhs -> printTermInline lhs <> sp <> op <> sp <> printTermInline rhs
     STeMatch scrut alts ->
-      printTerm scrut <> sp <> "match" <> sp <> "{\n"
-          <> concatMap (indentBlock 2 . printCase) alts
-          <> "}"
+      printTermInline scrut <> sp <> "match" <> sp <> "{\n"
+        <> intercalate "\n" (map (indentBlock 2 . printCase) alts)
+        <> "\n}"
     STeError err -> "sys.error(" <> "\"" <> escapeScalaString err <> "\"" <> ")"
+
+printIf :: ScalaTerm -> ScalaTerm -> ScalaTerm -> String
+printIf cond thenBranch elseBranch =
+    "if" <> sp <> "(" <> printTermInline cond <> ")" <> nl
+        <> indentBlock 2 (printTermBlock thenBranch)
+        <> nl
+        <> "else"
+        <> printElseBranch elseBranch
+
+printElseBranch :: ScalaTerm -> String
+printElseBranch elseBranch =
+    case elseBranch of
+        STeIf{} -> sp <> printTermBlock elseBranch
+        _ -> nl <> indentBlock 2 (printTermBlock elseBranch)
 
 printCase :: (ScalaPat, ScalaTerm) -> String
 printCase (pat, rhs) =
-  "case" <> sp <> printPat pat <> sp <> "=>" <> sp <> printTerm rhs
+  "case" <> sp <> printPat pat <> sp <> "=>"
+      <> nl
+      <> indentBlock 2 (printTermBlock rhs)
 
 -- ===== Vars / packages ======================================================
 
@@ -176,9 +197,6 @@ printObject pName = "object" <> sp <> pName
 bracket :: String -> String
 bracket str = "{\n" <> str <> "\n}"
 
-sp :: String
-sp = " "
-
 printCompanionObject :: ScalaName -> [String] -> String
 printCompanionObject name ctorLines =
     "object"
@@ -189,4 +207,4 @@ printCompanionObject name ctorLines =
 
 
 indentBlock :: Int -> String -> String
-indentBlock n = unlines . map (replicate n ' ' <>) . lines
+indentBlock n = intercalate "\n" . map (replicate n ' ' <>) . lines

--- a/src/Agda/Compiler/Scala/Render/PrintScala2.hs
+++ b/src/Agda/Compiler/Scala/Render/PrintScala2.hs
@@ -9,10 +9,15 @@ module Agda.Compiler.Scala.Render.PrintScala2 (
     combineLines
 ) where
 
-import Data.List (dropWhileEnd, intercalate)
+import Data.List (intercalate)
 
 import Agda.Compiler.Scala.Render.Common
   ( escapeScalaString
+  , asBottom
+  , multiLineCommentBeg
+  , multiLineCommentEnd
+  , nl
+  , combineLines
   , printPat
   , printType
   , printTyParams
@@ -60,7 +65,14 @@ printScala2 def = case def of
     SeUnhandled "" _payload ->
         "" -- filtered out
     SeUnhandled name payload ->
-        "/* TODO In printScala2 got SeUnhandled " <> show name <> " " <> show payload <> " */" <> nl
+        multiLineCommentBeg
+        <> " TODO In printScala2 got SeUnhandled "
+        <> show name
+        <> " "
+        <> show payload
+        <> " "
+        <> multiLineCommentEnd
+        <> nl
 
 -- ===== Sum types ============================================================
 
@@ -87,9 +99,6 @@ printCtor superName tyParams (ScalaCtor name argTys) =
         <> sp
         <> superName
         <> printTyParams tyParams
-
-asBottom :: [ScalaName] -> [ScalaName]
-asBottom ps = replicate (length ps) "Nothing"
 
 ctorParam :: Int -> ScalaType -> String
 ctorParam i ty = "x" <> show i <> ":" <> sp <> printType ty
@@ -167,15 +176,8 @@ printObject pName = "object" <> sp <> pName
 bracket :: String -> String
 bracket str = "{\n" <> str <> "\n}"
 
-sp, nl :: String
+sp :: String
 sp = " "
-nl = "\n"
-
-combineLines :: [String] -> String
-combineLines xs = strip (unlines (filter (not . null) xs))
-
-strip :: String -> String
-strip = dropWhileEnd (== '\n')
 
 printCompanionObject :: ScalaName -> [String] -> String
 printCompanionObject name ctorLines =
@@ -183,10 +185,8 @@ printCompanionObject name ctorLines =
         <> sp
         <> name
         <> sp
-        <> "{\n"
-        <> indentBlock 2 (combineLines ctorLines)
-        <> "\n"
-        <> "}"
+        <> bracket (indentBlock 2 (combineLines ctorLines))
+
 
 indentBlock :: Int -> String -> String
 indentBlock n = unlines . map (replicate n ' ' <>) . lines

--- a/src/Agda/Compiler/Scala/Render/PrintScala3.hs
+++ b/src/Agda/Compiler/Scala/Render/PrintScala3.hs
@@ -103,6 +103,13 @@ printTerm (STeError err) = "sys.error(" <> "\"" <> escapeScalaString err <> "\""
 printTerm (STeMatch scrut alts) =
   printTerm scrut <> " match" <> defsSeparator
     <> combineLinesWithIndent (indent <> indent) (map printCase alts)
+printTerm (STeIf cond thenBranch elseBranch) =
+  "if" <> exprSeparator <> "(" <> printTerm cond <> ")" <> exprSeparator
+    <> printTerm thenBranch
+    <> exprSeparator <> "else" <> exprSeparator
+    <> printTerm elseBranch
+printTerm (STeBinOp lhs op rhs) =
+  printTerm lhs <> exprSeparator <> op <> exprSeparator <> printTerm rhs
 
 printCase :: (ScalaPat, ScalaTerm) -> String
 printCase (pat, rhs) =

--- a/src/Agda/Compiler/Scala/Render/PrintScala3.hs
+++ b/src/Agda/Compiler/Scala/Render/PrintScala3.hs
@@ -4,14 +4,17 @@ module Agda.Compiler.Scala.Render.PrintScala3 (
     printSealedTrait,
     printPackageAndObject,
     printCaseClass,
-    combineLines,
 ) where
 
 import Agda.Compiler.Scala.Render.Common
   ( escapeScalaString
+  , asBottom
+  , colonSeparator
+  , nl
   , printPat
   , printType
   , printTyParams
+  , strip
   )
 import Agda.Compiler.Scala.IR.ScalaExpr (
     ScalaCtor (..),
@@ -30,7 +33,7 @@ printScala3 def = case def of
     (SePackage pNames defs) ->
         printPackageAndObject pNames
             <> bracket (map printScala3 defs)
-            <> blankLine -- EOF
+            <> nl -- EOF
     (SeSum name tyParams ctors) ->
         printSum name tyParams ctors
             <> defsSeparator
@@ -42,7 +45,7 @@ printScala3 def = case def of
             <> "("
             <> combineThem (map printVar args)
             <> ")"
-            <> ":"
+            <> colonSeparator
             <> exprSeparator
             <> printType (ssType resType)
             <> exprSeparator
@@ -52,7 +55,12 @@ printScala3 def = case def of
             <> defsSeparator
     (SeProd name _tyParams args) -> printCaseClass name args <> defsSeparator
     (SeUnhandled "" _payload) -> ""
-    (SeUnhandled name payload) -> "TODO In printScala3 got SeUnhandled " ++ show name ++ " " ++ show payload
+    (SeUnhandled name payload) -> "/* TODO In printScala3 got SeUnhandled "
+      <> show name
+      <> " "
+      <> show payload
+      <> "*/"
+      <> defsSeparator
 
 -- ===== Sum types ============================================================
 
@@ -77,9 +85,6 @@ printEnumCtor name tyParams (ScalaCtor cName argTys) =
         <> intercalate ", " (zipWith ctorParam [0 :: Int ..] argTys)
         <> ")"
         <> printExtends name tyParams
-
-asBottom :: [ScalaName] -> [ScalaName]
-asBottom ps = replicate (length ps) "Nothing"
 
 printExtends :: ScalaName -> [ScalaName] -> String
 printExtends _ [] = ""
@@ -162,26 +167,14 @@ bracketWithIndent str i =
 defsSeparator :: String
 defsSeparator = "\n"
 
-blankLine :: String
-blankLine = "\n"
-
 exprSeparator :: String
 exprSeparator = " "
-
-colonSeparator :: String
-colonSeparator = ":"
 
 indent :: String
 indent = "  "
 
 times :: Int -> [a] -> [a]
 times i s = concat $ replicate i s
-
-strip :: String -> String
-strip xs = reverse $ dropWhile (== '\n') (reverse xs)
-
-combineLines :: [String] -> String
-combineLines xs = strip $ unlines (filter (not . null) xs)
 
 combineLinesWithIndent :: String -> [String] -> String
 combineLinesWithIndent indent' xs = strip $ unlines (fmap (indent' ++) (filter (not . null) xs))

--- a/src/Agda/Compiler/Scala/Render/PrintScala3.hs
+++ b/src/Agda/Compiler/Scala/Render/PrintScala3.hs
@@ -15,6 +15,7 @@ import Agda.Compiler.Scala.Render.Common
   , printType
   , printTyParams
   , strip
+  , sp
   )
 import Agda.Compiler.Scala.IR.ScalaExpr (
     ScalaCtor (..),
@@ -97,29 +98,49 @@ printCaseClass :: ScalaName -> [SeVar] -> String
 printCaseClass name args = "final case class" <> exprSeparator <> name <> "(" <> printExpr args <> ")"
 
 printTerm :: ScalaTerm -> String
-printTerm (STeVar scalaName) = scalaName
-printTerm (STeApp st sts) =
-    printTerm st <> "(" <> intercalate ", " (map printTerm sts) <> ")"
-printTerm (STeLam sns st) = "(" <> intercalate ", " sns <> ")" <> exprSeparator <> "=>" <> exprSeparator <> printTerm st
-printTerm (STeLitInt n) = show n
-printTerm (STeLitBool b) = if b then "true" else "false"
-printTerm (STeLitString s) = "\"" <> escapeScalaString s <> "\""
-printTerm (STeError err) = "sys.error(" <> "\"" <> escapeScalaString err <> "\"" <> ")"
-printTerm (STeMatch scrut alts) =
-  printTerm scrut <> " match" <> defsSeparator
-    <> combineLinesWithIndent (indent <> indent) (map printCase alts)
-printTerm (STeIf cond thenBranch elseBranch) =
-  "if" <> exprSeparator <> "(" <> printTerm cond <> ")" <> exprSeparator
-    <> printTerm thenBranch
-    <> exprSeparator <> "else" <> exprSeparator
-    <> printTerm elseBranch
-printTerm (STeBinOp lhs op rhs) =
-  printTerm lhs <> exprSeparator <> op <> exprSeparator <> printTerm rhs
+printTerm = printTermBlock
+
+printTermInline :: ScalaTerm -> String
+printTermInline term =
+    case term of
+        STeIf{} -> "(" <> printTermBlock term <> ")"
+        STeMatch{} -> "(" <> printTermBlock term <> ")"
+        _ -> printTermBlock term
+
+printTermBlock :: ScalaTerm -> String
+printTermBlock term =
+    case term of
+        STeVar scalaName -> scalaName
+        STeApp st sts -> printTermInline st <> "(" <> intercalate ", " (map printTermInline sts) <> ")"
+        STeLam sns st -> "(" <> intercalate ", " sns <> ")" <> exprSeparator <> "=>" <> exprSeparator <> printTermInline st
+        STeLitInt n -> show n
+        STeLitBool b -> if b then "true" else "false"
+        STeLitString s -> "\"" <> escapeScalaString s <> "\""
+        STeIf cond thenBranch elseBranch -> printIf cond thenBranch elseBranch
+        STeBinOp lhs op rhs -> printTermInline lhs <> exprSeparator <> op <> exprSeparator <> printTermInline rhs
+        STeError err -> "sys.error(" <> "\"" <> escapeScalaString err <> "\"" <> ")"
+        STeMatch scrut alts ->
+            printTermInline scrut <> sp <> "match" <> nl
+                <> indentBlock 2 (intercalate "\n" (map printCase alts))
+
+printIf :: ScalaTerm -> ScalaTerm -> ScalaTerm -> String
+printIf cond thenBranch elseBranch =
+    "if" <> sp <> printTermInline cond <> sp <> "then" <> nl
+        <> indentBlock 2 (printTermBlock thenBranch)
+        <> nl
+        <> "else"
+        <> printElseBranch elseBranch
+
+printElseBranch :: ScalaTerm -> String
+printElseBranch elseBranch =
+    case elseBranch of
+        STeIf{} -> sp <> printTermBlock elseBranch
+        _ -> nl <> indentBlock 2 (printTermBlock elseBranch)
 
 printCase :: (ScalaPat, ScalaTerm) -> String
 printCase (pat, rhs) =
-  "case" <> exprSeparator <> printPat pat
-    <> exprSeparator <> "=>" <> exprSeparator <> printTerm rhs
+    "case" <> sp <> printPat pat <> sp <> "=>" <> nl
+        <> indentBlock 2 (printTermBlock rhs)
 
 printVar :: SeVar -> String
 printVar (SeVar sName sType) = sName <> colonSeparator <> exprSeparator <> (printType sType)
@@ -156,25 +177,37 @@ printPackage pNames = "package" <> exprSeparator <> intercalate "." pNames
 printObject :: ScalaName -> String
 printObject pName = "object" <> exprSeparator <> pName
 
-bracket :: [String] -> String
-bracket str = colonSeparator <> defsSeparator <> combineLinesWithIndent indent str
-
--- -- TODO Scala3 indents
-bracketWithIndent :: [String] -> Int -> String
-bracketWithIndent str i =
-    colonSeparator <> defsSeparator <> combineLinesWithIndent (times i indent) str
-
 defsSeparator :: String
 defsSeparator = "\n"
 
 exprSeparator :: String
 exprSeparator = " "
 
-indent :: String
-indent = "  "
+-- -- TODO Scala3 indents
+bracket :: [String] -> String
+bracket blocks =
+    colonSeparator <> defsSeparator <> combineMemberBlocksWithIndent 2 blocks
 
-times :: Int -> [a] -> [a]
-times i s = concat $ replicate i s
+bracketWithIndent :: [String] -> Int -> String
+bracketWithIndent blocks i =
+    colonSeparator <> defsSeparator <> combineBlocksWithIndent i blocks
 
-combineLinesWithIndent :: String -> [String] -> String
-combineLinesWithIndent indent' xs = strip $ unlines (fmap (indent' ++) (filter (not . null) xs))
+combineMemberBlocksWithIndent :: Int -> [String] -> String
+combineMemberBlocksWithIndent n blocks =
+    intercalate (defsSeparator <> defsSeparator) $
+        map (indentBlock n) $
+            nonEmptyBlocks blocks
+
+combineBlocksWithIndent :: Int -> [String] -> String
+combineBlocksWithIndent n blocks =
+    intercalate defsSeparator $
+        map (indentBlock n) $
+            nonEmptyBlocks blocks
+
+nonEmptyBlocks :: [String] -> [String]
+nonEmptyBlocks =
+    filter (not . null) . map strip
+
+indentBlock :: Int -> String -> String
+indentBlock n =
+    intercalate "\n" . map (replicate n ' ' <>) . lines

--- a/test/Compile/TermsProps.hs
+++ b/test/Compile/TermsProps.hs
@@ -22,8 +22,11 @@ import Agda.Syntax.TopLevelModuleName.Boot ( noModuleNameHash )
 import Agda.Compiler.Scala.Compile.Terms
   ( Env(..)
   , envFromArgs
+  , envFromFunction
   , extendEnv
+  , lookupCaseArg
   , lookupVar
+  , removeCaseArg
   )
 import Agda.Compiler.Scala.Compile (compileBodyTerm)
 import Agda.Compiler.Scala.Compile.Types (CompileError(..))
@@ -36,6 +39,11 @@ termsProps =
     , ("pattern vars extend Env with newest binder at index 0", prop_extendEnv_patternVarsNewestFirst)
     , ("function args enter Env with last arg at index 0", prop_envFromArgs_functionArgsNewestFirst)
     , ("lookupVar reports index and Env size when out of range", prop_lookupVar_outOfRange)
+    , ("function type params stay in Env as erased de Bruijn slots",
+       prop_envFromFunction_keepsTypeParamsForDeBruijnAlignment)
+    , ("case arguments use source-order positions including erased binders", prop_lookupCaseArg_usesSourceOrder)
+    , ("case branch environment removes the scrutinized argument", prop_removeCaseArg_dropsScrutinee)
+    , ("constructor branch binders are added after dropping the case scrutinee", prop_caseBranchEnv_addsPatternBindersAfterDroppingScrutinee)
     ]
 
 mkApply :: Term -> Elim' Term
@@ -47,8 +55,7 @@ mkApply t = Apply (defaultArg t)
 prop_def_apply_arity :: Property
 prop_def_apply_arity = property $ do
   k <- forAll (Gen.int (Range.linear 0 8))
-
-  let env = Env ["x"]
+  let env = Env [Just "x"]
       t =
         Def
           dummyQName
@@ -105,7 +112,58 @@ prop_lookupVar_outOfRange :: Property
 prop_lookupVar_outOfRange = property $ do
   size <- forAll (Gen.int (Range.linear 0 12))
   extra <- forAll (Gen.int (Range.linear 0 12))
-  let vars = [ "x" <> show i | i <- [0 .. size - 1] ]
+  let vars = [ Just ("x" <> show i) | i <- [0 .. size - 1] ]
       env  = Env vars
       ix   = size + extra
   lookupVar env ix === Left (VarOutOfRange ix size)
+
+-- Type parameters are erased at runtime, but preserved as empty slots in the de Bruijn environment:
+-- Term Env preserves Agda de Bruijn indexing.
+-- Visible term binders are stored as Just ScalaName.
+-- Erased type-level binders are stored as Nothing.
+-- This lets us erase type arguments from generated Scala while keeping Agda variable indices correct.
+prop_envFromFunction_keepsTypeParamsForDeBruijnAlignment :: Property
+prop_envFromFunction_keepsTypeParamsForDeBruijnAlignment = property $ do
+  tyCount <- forAll (Gen.int (Range.linear 1 5))
+  argCount <- forAll (Gen.int (Range.linear 1 8))
+
+  let tyParams = [ "A" <> show i | i <- [0 .. tyCount - 1] ]
+      args = [ "x" <> show i | i <- [0 .. argCount - 1] ]
+      env = envFromFunction tyParams args
+
+  traverse_
+    (\(i, expected) -> lookupVar env i === Right expected)
+    (zip [0 ..] (reverse args))
+
+  lookupVar env argCount === Left (ErasedVarReferenced argCount)
+
+prop_lookupCaseArg_usesSourceOrder :: Property
+prop_lookupCaseArg_usesSourceOrder = property $ do
+    let env = Env [Just "tree", Just "key", Just "defaultVal", Nothing]
+
+    lookupCaseArg env 1 === Right "defaultVal"
+    lookupCaseArg env 2 === Right "key"
+    lookupCaseArg env 3 === Right "tree"
+
+prop_removeCaseArg_dropsScrutinee :: Property
+prop_removeCaseArg_dropsScrutinee = property $ do
+    let env = Env [Just "tree", Just "key", Just "defaultVal", Nothing]
+
+    branchEnv <- evalEither (removeCaseArg env 3)
+
+    lookupVar branchEnv 0 === Right "key"
+    lookupVar branchEnv 1 === Right "defaultVal"
+    lookupVar branchEnv 2 === Left (ErasedVarReferenced 2)
+
+prop_caseBranchEnv_addsPatternBindersAfterDroppingScrutinee :: Property
+prop_caseBranchEnv_addsPatternBindersAfterDroppingScrutinee = property $ do
+    let env = Env [Just "tree", Just "key", Just "defaultVal", Nothing]
+        patVars = ["p0", "p1", "p2", "p3", "p4"]
+
+    branchEnv <- evalEither (removeCaseArg env 3)
+    let ctorEnv = extendEnv patVars branchEnv
+
+    lookupVar ctorEnv 0 === Right "p4"
+    lookupVar ctorEnv 3 === Right "p1"
+    lookupVar ctorEnv 5 === Right "key"
+    lookupVar ctorEnv 6 === Right "defaultVal"

--- a/test/Compile/TermsProps.hs
+++ b/test/Compile/TermsProps.hs
@@ -16,7 +16,7 @@ import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import Agda.Syntax.Abstract.Name ( QName, mkName_ , qualify_ )
-import Agda.Syntax.Common ( NameId(..), defaultArg)
+import Agda.Syntax.Common ( Arg, Hiding(..), NameId(..), defaultArg, setHiding )
 import Agda.Syntax.Internal (Elim' (..), Term (..))
 import Agda.Syntax.TopLevelModuleName.Boot ( noModuleNameHash )
 import Agda.Compiler.Scala.Compile.Terms
@@ -39,6 +39,7 @@ termsProps =
     , ("pattern vars extend Env with newest binder at index 0", prop_extendEnv_patternVarsNewestFirst)
     , ("function args enter Env with last arg at index 0", prop_envFromArgs_functionArgsNewestFirst)
     , ("lookupVar reports index and Env size when out of range", prop_lookupVar_outOfRange)
+    , ("hidden application arguments do not become runtime Scala arguments", prop_hiddenApplyArgs_areErased)
     , ("function type params stay in Env as erased de Bruijn slots",
        prop_envFromFunction_keepsTypeParamsForDeBruijnAlignment)
     , ("case arguments use source-order positions including erased binders", prop_lookupCaseArg_usesSourceOrder)
@@ -167,3 +168,23 @@ prop_caseBranchEnv_addsPatternBindersAfterDroppingScrutinee = property $ do
     lookupVar ctorEnv 3 === Right "p1"
     lookupVar ctorEnv 5 === Right "key"
     lookupVar ctorEnv 6 === Right "defaultVal"
+
+prop_hiddenApplyArgs_areErased :: Property
+prop_hiddenApplyArgs_areErased = property $ do
+    let env = envFromFunction ["A"] ["x"]
+        term = Def
+          dummyQName
+          [ Apply (hiddenArg (Var 1 []))
+          , Apply (visibleArg (Var 0 []))
+          ]
+        expected =
+            STeApp
+                (STeVar "f")
+                [STeVar "x"]
+    compileBodyTerm env term === Right expected
+
+visibleArg :: Term -> Arg Term
+visibleArg = defaultArg
+
+hiddenArg :: Term -> Arg Term
+hiddenArg = setHiding Hidden . defaultArg

--- a/test/CompileProps.hs
+++ b/test/CompileProps.hs
@@ -52,7 +52,7 @@ genEnv = do
     -- env[0] = last binder, so store in the actual runtime order already
     n <- Gen.int (Range.linear 0 30)
     xs <- Gen.list (Range.singleton n) genName
-    pure (Env xs)
+    pure (Env (map Just xs))
 
 genName :: Gen String
 genName = Gen.string (Range.linear 1 12) Gen.alphaNum
@@ -81,7 +81,9 @@ prop_lookupVar_inRange :: Property
 prop_lookupVar_inRange = property $ do
     env@(Env xs) <- forAll genEnv
     i <- forAll (genIndexInRange env)
-    lookupVar env i === Right (xs !! i)
+    case xs !! i of
+        Just name -> lookupVar env i === Right name
+        Nothing -> failure
 
 prop_lookupVar_outOfRange :: Property
 prop_lookupVar_outOfRange = property $ do
@@ -112,9 +114,10 @@ prop_compileBodyTerm_varResolves :: Property
 prop_compileBodyTerm_varResolves = property $ do
     env@(Env xs) <- forAll genEnv
     i <- forAll (genIndexInRange env)
-
     -- Term-level Var i should resolve to env[i]
-    compileBodyTerm env (Var i []) === Right (STeVar (xs !! i))
+    case xs !! i of
+        Just name -> compileBodyTerm env (Var i []) === Right (STeVar name)
+        Nothing -> failure
 
 -- smoke property for compileTypeTerm on a generated subset
 prop_compileTypeTerm_total_onSubset :: Property
@@ -135,7 +138,8 @@ prop_compileBodyTerm_varLaw :: Property
 prop_compileBodyTerm_varLaw = property $ do
     xs <- forAll (Gen.list (Range.linear 1 50) genName)
     i <- forAll (Gen.int (Range.linear 0 (length xs - 1)))
-    compileBodyTerm (Env xs) (Var i []) === Right (STeVar (xs !! i))
+    let env = Env (map Just xs)
+    compileBodyTerm env (Var i []) === Right (STeVar (xs !! i))
 
 prop_compileBodyTerm_literals :: Property
 prop_compileBodyTerm_literals = property $ do

--- a/test/Render/CommonTest.hs
+++ b/test/Render/CommonTest.hs
@@ -1,18 +1,19 @@
 module Render.CommonTest (tests) where
 
 import Test.Tasty (testGroup, TestTree)
-import Test.Tasty.HUnit (assertEqual, testCase)
+import Test.Tasty.HUnit (testCase)
 
 import Agda.Compiler.Scala.Render.Common (combineLines)
+import Support.Assertions (assertStringEqual)
 
 tests :: TestTree
-tests = testGroup "combineLines"
+tests = testGroup "Render.Common"
   [ testCase "combineLines removes empty lines and joins non-empty lines" test_combineLines
   ]
 
 test_combineLines :: IO ()
 test_combineLines =
-    assertEqual
+    assertStringEqual
         "combined lines"
         "a\nb"
         (combineLines ["", "a", "", "", "b", "", "", ""])

--- a/test/Render/CommonTest.hs
+++ b/test/Render/CommonTest.hs
@@ -1,0 +1,18 @@
+module Render.CommonTest (tests) where
+
+import Test.Tasty (testGroup, TestTree)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+import Agda.Compiler.Scala.Render.Common (combineLines)
+
+tests :: TestTree
+tests = testGroup "combineLines"
+  [ testCase "combineLines removes empty lines and joins non-empty lines" test_combineLines
+  ]
+
+test_combineLines :: IO ()
+test_combineLines =
+    assertEqual
+        "combined lines"
+        "a\nb"
+        (combineLines ["", "a", "", "", "b", "", "", ""])

--- a/test/Render/PrintScala2Test.hs
+++ b/test/Render/PrintScala2Test.hs
@@ -1,7 +1,7 @@
 module Render.PrintScala2Test (tests) where
 
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (assertEqual, testCase)
+import Test.Tasty.HUnit (testCase)
 
 import Agda.Compiler.Scala.IR.ScalaExpr
     ( ScalaCtor (..)
@@ -14,7 +14,7 @@ import Agda.Compiler.Scala.IR.ScalaExpr
     , scalaTypeScheme
     )
 import Agda.Compiler.Scala.Render.PrintScala2
-    ( combineLines
+    ( combineDecls
     , printCaseClass
     , printCaseObject
     , printPackageAndObject
@@ -47,9 +47,9 @@ tests =
             ]
         , testGroup
             "layout"
-            [ testCase "combineLines removes empty lines and joins non-empty lines" test_combineLines
-            , testCase "prints package with handled declarations and skips empty unhandled declarations"
+            [ testCase "prints package with handled declarations and skips empty unhandled declarations"
                        test_printScala2Package
+              , testCase "combineDecls strips trailing newlines before joining declarations" test_combineDecls_strips_newlines
             ]
         , testGroup
             "pattern matching"
@@ -64,49 +64,42 @@ tests =
 
 test_printCaseObject :: IO ()
 test_printCaseObject =
-    assertEqual
+    assertStringEqual
         "Scala 2 case object"
         "case object Light extends Color"
         (printCaseObject "Color" "Light")
 
 test_printSealedTrait :: IO ()
 test_printSealedTrait =
-    assertEqual
+    assertStringEqual
         "Scala 2 sealed trait"
         "sealed trait Color"
         (printSealedTrait "Color")
 
 test_objectWhenNoPackage :: IO ()
 test_objectWhenNoPackage =
-    assertEqual
+    assertStringEqual
         "Scala 2 object"
         "object adts"
         (printPackageAndObject ["adts"])
 
 test_packageAndObject :: IO ()
 test_packageAndObject =
-    assertEqual
+    assertStringEqual
         "Scala 2 package and object"
         "package example\n\nobject adts"
         (printPackageAndObject ["example", "adts"])
 
 test_multiplePartPackageAndObject :: IO ()
 test_multiplePartPackageAndObject =
-    assertEqual
+    assertStringEqual
         "Scala 2 dotted package and object"
         "package org.example\n\nobject adts"
         (printPackageAndObject ["org", "example", "adts"])
 
-test_combineLines :: IO ()
-test_combineLines =
-    assertEqual
-        "combined lines"
-        "a\nb"
-        (combineLines ["", "a", "", "", "b", "", "", ""])
-
 test_printCaseClass :: IO ()
 test_printCaseClass =
-    assertEqual
+    assertStringEqual
         "Scala 2 case class"
         "final case class RgbPair(snd: Bool, fst: Rgb)"
         ( printCaseClass
@@ -119,7 +112,7 @@ test_printCaseClass =
 
 test_printCaseClassPoly :: IO ()
 test_printCaseClassPoly =
-    assertEqual
+    assertStringEqual
         "Scala 2 polymorphic case class"
         "final case class Box[A](unbox: A)"
         ( printCaseClass
@@ -308,3 +301,10 @@ test_print_if_breaks_branches =
             <> "  lookup(x1, x2, p4)\n"
             <> "else\n"
             <> "  p3\n"
+
+test_combineDecls_strips_newlines :: IO ()
+test_combineDecls_strips_newlines =
+    assertStringEqual
+        "combineDecls strips trailing newlines before joining declarations"
+        "a\n\nb"
+        (combineDecls ["a\n", "", "b\n"])

--- a/test/Render/PrintScala2Test.hs
+++ b/test/Render/PrintScala2Test.hs
@@ -53,6 +53,10 @@ tests =
             "pattern matching"
             [ testCase "prints flat constructor match" test_printMatch
             ]
+         , testGroup
+            "it then else"
+            [ testCase "prints if then else" test_print_if_then_else
+            ]
         ]
 
 test_printCaseObject :: IO ()
@@ -242,9 +246,29 @@ test_printMatch =
                 , (SPCtor "Answer.No" [], STeVar "Answer.Yes")
                 ]
             )
-
     expected =
         "def not(x0: Answer): Answer = x0 match {\n"
             <> "  case Answer.Yes => Answer.No\n"
             <> "  case Answer.No => Answer.Yes\n"
             <> "}\n"
+
+test_print_if_then_else :: IO ()
+test_print_if_then_else =
+  assertStringEqual "printScala2 if then else"
+    expected
+    (printScala2 expr)
+  where
+    expr =
+      SeFun
+        "choose"
+        [ SeVar "x" (STyName "Long")
+        , SeVar "y" (STyName "Long")
+        ]
+        (scalaTypeScheme (STyName "Long"))
+        ( STeIf
+            (STeBinOp (STeVar "x") "<" (STeVar "y"))
+            (STeVar "x")
+            (STeVar "y")
+        )
+    expected =
+      "def choose(x: Long, y: Long): Long = if (x < y) x else y\n"

--- a/test/Render/PrintScala2Test.hs
+++ b/test/Render/PrintScala2Test.hs
@@ -32,7 +32,8 @@ tests =
             "module headers"
             [ testCase "prints object when module has one name part" test_objectWhenNoPackage
             , testCase "prints package and object for two-part module name" test_packageAndObject
-            , testCase "prints dotted package and object for multi-part module name" test_multiplePartPackageAndObject
+            , testCase "prints dotted package and object for multi-part module name"
+                       test_multiplePartPackageAndObject
             ]
         , testGroup
             "declarations"
@@ -47,7 +48,8 @@ tests =
         , testGroup
             "layout"
             [ testCase "combineLines removes empty lines and joins non-empty lines" test_combineLines
-            , testCase "prints package with handled declarations and skips empty unhandled declarations" test_printScala2Package
+            , testCase "prints package with handled declarations and skips empty unhandled declarations"
+                       test_printScala2Package
             ]
         , testGroup
             "pattern matching"
@@ -56,6 +58,7 @@ tests =
          , testGroup
             "it then else"
             [ testCase "prints if then else" test_print_if_then_else
+            , testCase "printer breaks if/else branches" test_print_if_breaks_branches
             ]
         ]
 
@@ -158,14 +161,12 @@ test_printScala2Package =
             <> "  case object Red extends Rgb\n"
             <> "  case object Green extends Rgb\n"
             <> "  case object Blue extends Rgb\n"
-            <> "\n"
             <> "}\n"
             <> "\n"
             <> "sealed trait Color\n"
             <> "object Color {\n"
             <> "  case object Light extends Color\n"
             <> "  case object Dark extends Color\n"
-            <> "\n"
             <> "}\n"
             <> "}\n"
 
@@ -189,7 +190,6 @@ test_printSum =
             <> "  case object Red extends Rgb\n"
             <> "  case object Green extends Rgb\n"
             <> "  case object Blue extends Rgb\n"
-            <> "\n"
             <> "}"
 
 test_printSumPoly :: IO ()
@@ -210,7 +210,6 @@ test_printSumPoly =
             <> "object Maybe {\n"
             <> "  case object None extends Maybe[Nothing]\n"
             <> "  final case class Just[A](x0: A) extends Maybe[A]\n"
-            <> "\n"
             <> "}"
 
 test_polyDef :: IO ()
@@ -248,8 +247,10 @@ test_printMatch =
             )
     expected =
         "def not(x0: Answer): Answer = x0 match {\n"
-            <> "  case Answer.Yes => Answer.No\n"
-            <> "  case Answer.No => Answer.Yes\n"
+            <> "  case Answer.Yes =>\n"
+            <> "    Answer.No\n"
+            <> "  case Answer.No =>\n"
+            <> "    Answer.Yes\n"
             <> "}\n"
 
 test_print_if_then_else :: IO ()
@@ -271,4 +272,39 @@ test_print_if_then_else =
             (STeVar "y")
         )
     expected =
-      "def choose(x: Long, y: Long): Long = if (x < y) x else y\n"
+       ""
+       <> "def choose(x: Long, y: Long): Long = if (x < y)\n"
+       <> "  x\n"
+       <> "else\n"
+       <> "  y\n"
+
+test_print_if_breaks_branches :: IO ()
+test_print_if_breaks_branches =
+    assertStringEqual
+            "multiline if"
+            expected
+            (printScala2 expr)
+  where
+    expr =
+        SeFun
+            "lookup"
+            [ SeVar "x1" (STyVar "V")
+            , SeVar "x2" (STyName "Long")
+            ]
+            (ScalaTypeScheme ["V"] (STyVar "V"))
+            ( STeIf
+                (STeBinOp (STeVar "x2") "<" (STeVar "p2"))
+                (STeApp (STeVar "lookup") [STeVar "x1", STeVar "x2", STeVar "p1"])
+                ( STeIf
+                    (STeBinOp (STeVar "p2") "<" (STeVar "x2"))
+                    (STeApp (STeVar "lookup") [STeVar "x1", STeVar "x2", STeVar "p4"])
+                    (STeVar "p3")
+                )
+            )
+    expected =
+        "def lookup[V](x1: V, x2: Long): V = if (x2 < p2)\n"
+            <> "  lookup(x1, x2, p1)\n"
+            <> "else if (p2 < x2)\n"
+            <> "  lookup(x1, x2, p4)\n"
+            <> "else\n"
+            <> "  p3\n"

--- a/test/Render/PrintScala3Test.hs
+++ b/test/Render/PrintScala3Test.hs
@@ -46,6 +46,10 @@ tests =
             [ testCase "prints flat constructor match" test_printMatch
             , testCase "prints flat constructor match with application on the right-hand side" test_printMatchWithAppRhs
             ]
+         , testGroup
+            "it then else"
+            [ testCase "prints if then else" test_print_if_then_else
+            ]
         ]
 
 test_printCaseObject :: IO ()
@@ -168,3 +172,23 @@ test_printMatchWithAppRhs =
         "def normalize(x0: Answer): Answer = x0 match\n"
             <> "    case Answer.Yes => wrap(Answer.No)\n"
             <> "    case Answer.No => wrap(Answer.Yes)\n"
+
+test_print_if_then_else :: IO ()
+test_print_if_then_else =
+  assertStringEqual "printScala3 if then else"
+    expected
+    (printScala3 expr)
+  where
+    expr =
+      SeFun
+        "choose"
+        [ SeVar "x" (STyName "Long")
+        , SeVar "y" (STyName "Long")
+        ]
+        (scalaTypeScheme (STyName "Long"))
+        ( STeIf
+            (STeBinOp (STeVar "x") "<" (STeVar "y"))
+            (STeVar "x")
+            (STeVar "y")
+        )
+    expected = "def choose(x: Long, y: Long): Long = if (x < y) x else y\n"

--- a/test/Render/PrintScala3Test.hs
+++ b/test/Render/PrintScala3Test.hs
@@ -13,8 +13,7 @@ import Agda.Compiler.Scala.IR.ScalaExpr
     , scalaTypeScheme
     )
 import Agda.Compiler.Scala.Render.PrintScala3
-    ( combineLines
-    , printCaseClass
+    ( printCaseClass
     , printCaseObject
     , printPackageAndObject
     , printScala3
@@ -38,8 +37,7 @@ tests =
             ]
         , testGroup
             "layout"
-            [ testCase "combineLines removes empty lines and joins non-empty lines" test_combineLines
-            , testCase "prints package with two enum declarations and skips empty unhandled declarations" test_printScala3Package
+            [ testCase "prints package with two enum declarations and skips empty unhandled declarations" test_printScala3Package
             ]
         , testGroup
             "pattern matching"
@@ -72,13 +70,6 @@ test_printPackage =
         "Scala 3 object"
         "object adts"
         (printPackageAndObject ["adts"])
-
-test_combineLines :: IO ()
-test_combineLines =
-    assertEqual
-        "combined lines"
-        "a\nb"
-        (combineLines ["", "a", "", "", "b", "", "", ""])
 
 test_printCaseClass :: IO ()
 test_printCaseClass =

--- a/test/Render/PrintScala3Test.hs
+++ b/test/Render/PrintScala3Test.hs
@@ -138,8 +138,10 @@ test_printMatch =
             )
     expected =
         "def not(x0: Answer): Answer = x0 match\n"
-            <> "    case Answer.Yes => Answer.No\n"
-            <> "    case Answer.No => Answer.Yes\n"
+            <> "  case Answer.Yes =>\n"
+            <> "    Answer.No\n"
+            <> "  case Answer.No =>\n"
+            <> "    Answer.Yes\n"
 
 test_printMatchWithAppRhs :: IO ()
 test_printMatchWithAppRhs =
@@ -161,8 +163,10 @@ test_printMatchWithAppRhs =
             )
     expected =
         "def normalize(x0: Answer): Answer = x0 match\n"
-            <> "    case Answer.Yes => wrap(Answer.No)\n"
-            <> "    case Answer.No => wrap(Answer.Yes)\n"
+            <> "  case Answer.Yes =>\n"
+            <> "    wrap(Answer.No)\n"
+            <> "  case Answer.No =>\n"
+            <> "    wrap(Answer.Yes)\n"
 
 test_print_if_then_else :: IO ()
 test_print_if_then_else =
@@ -182,4 +186,8 @@ test_print_if_then_else =
             (STeVar "x")
             (STeVar "y")
         )
-    expected = "def choose(x: Long, y: Long): Long = if (x < y) x else y\n"
+    expected = ""
+     <> "def choose(x: Long, y: Long): Long = if x < y then\n"
+     <> "  x\n"
+     <> "else\n"
+     <> "  y\n"

--- a/test/Render/PrintScala3Test.hs
+++ b/test/Render/PrintScala3Test.hs
@@ -1,7 +1,7 @@
 module Render.PrintScala3Test (tests) where
 
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (assertEqual, testCase)
+import Test.Tasty.HUnit (testCase)
 
 import Agda.Compiler.Scala.IR.ScalaExpr
     ( ScalaCtor (..)
@@ -52,28 +52,28 @@ tests =
 
 test_printCaseObject :: IO ()
 test_printCaseObject =
-    assertEqual
+    assertStringEqual
         "Scala 3 case object"
         "case object Light extends Color"
         (printCaseObject "Color" "Light")
 
 test_printSealedTrait :: IO ()
 test_printSealedTrait =
-    assertEqual
+    assertStringEqual
         "Scala 3 sealed trait"
         "sealed trait Color"
         (printSealedTrait "Color")
 
 test_printPackage :: IO ()
 test_printPackage =
-    assertEqual
+    assertStringEqual
         "Scala 3 object"
         "object adts"
         (printPackageAndObject ["adts"])
 
 test_printCaseClass :: IO ()
 test_printCaseClass =
-    assertEqual
+    assertStringEqual
         "Scala 3 case class"
         "final case class RgbPair(snd: Bool, fst: Rgb)"
         ( printCaseClass

--- a/test/Support/Assertions.hs
+++ b/test/Support/Assertions.hs
@@ -6,37 +6,36 @@ module Support.Assertions
   ) where
 
 import Control.Monad (unless)
+import GHC.Stack
+  ( HasCallStack
+  )
 import Test.Tasty.HUnit (Assertion, assertFailure)
 
-assertEqualPretty :: (Eq a, Show a) => String -> a -> a -> Assertion
+assertEqualPretty :: (HasCallStack, Eq a, Show a) => String -> a -> a -> Assertion
 assertEqualPretty label expected actual =
     unless (expected == actual) $
         assertFailure $
             unlines
                 [ label
-                , ""
                 , "Expected:"
                 , indent (show expected)
-                , ""
                 , "Actual:"
                 , indent (show actual)
                 ]
 
-assertStringEqual :: String -> String -> String -> Assertion
+assertStringEqual :: HasCallStack => String -> String -> String -> Assertion
 assertStringEqual label expected actual =
     unless (expected == actual) $
         assertFailure $
             unlines
                 [ label
-                , ""
                 , "Expected:"
                 , fence expected
-                , ""
                 , "Actual:"
                 , fence actual
                 ]
 
-assertLeft :: (Show a) => String -> Either e a -> Assertion
+assertLeft :: (HasCallStack, Show a) => String -> Either e a -> Assertion
 assertLeft label actual =
     case actual of
         Left _ -> pure ()
@@ -44,15 +43,13 @@ assertLeft label actual =
             assertFailure $
                 unlines
                     [ label
-                    , ""
                     , "Expected:"
                     , "  Left _"
-                    , ""
                     , "Actual:"
                     , indent (show value)
                     ]
 
-assertRight :: (Show e) => String -> Either e a -> Assertion
+assertRight :: (HasCallStack, Show e) => String -> Either e a -> Assertion
 assertRight label actual =
     case actual of
         Right _ -> pure ()
@@ -60,10 +57,8 @@ assertRight label actual =
             assertFailure $
                 unlines
                     [ label
-                    , ""
                     , "Expected:"
                     , "  Right _"
-                    , ""
                     , "Actual:"
                     , indent (show err)
                     ]

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -4,6 +4,7 @@ import Test.Tasty (TestTree, defaultMain, testGroup)
 
 import qualified Name.NameEnvTest
 import qualified Name.NamePolicyTest
+import qualified Render.CommonTest
 import qualified Render.PrintScala2Test
 import qualified Render.PrintScala3Test
 import qualified ScalaBackendTest
@@ -19,6 +20,7 @@ tests =
         "agda2scala unit tests"
         [ Name.NameEnvTest.tests
         , Name.NamePolicyTest.tests
+        , Render.CommonTest.tests
         , Render.PrintScala2Test.tests
         , Render.PrintScala3Test.tests
         , ScalaBackendTest.tests


### PR DESCRIPTION
* Add support for:
  * `if_then_else_` into Scala if then else
  * binary operators
  * natural numbers `_ <ᵇ _` into Scala `<`

Technical details about changes in lowering compiler output to AgdaIR and then to ScalaIR:
- Erase hidden/type-level application arguments during term lowering.
  Agda applications can include hidden arguments such as `{V}` or level/type arguments that do not exist at Scala runtime. For example, recursive `lookup` calls appear in Agda internals as something like `lookup {V} defaultVal key left`; Scala must emit `lookup(defaultVal, key, left)`, not try to compile `{V}` as a value argument. Handled by `compileVisibleApplyTerms` / `compileVisibleElim`, used by normal function application, constructor application, `if_then_else_`, and binary operators.

- Preserve erased type parameters in the term environment for correct de Bruijn indexing.
  Even though `{V}` is erased from generated Scala, Agda de Bruijn indices still count it. For `lookup : {V : Set} -> V -> ℕ -> RedBlackTree V -> V`, the term environment must contain an erased slot for `V`, otherwise `Var` indices shift and point to the wrong runtime variables. Handled by `Env [Maybe ScalaName]` and `envFromFunction`, where `Nothing` represents an erased binder kept only for index alignment.

- Handle Agda compiled `Case` indices separately from normal `Var` indices.
  `Var i` uses de Bruijn order: newest binder first. But compiled `Case i` refers to function-argument position order, left-to-right, including erased binders. In `lookup {V} defaultVal key tree`, `Case 3` means “case on `tree`”, while `Var 3` means the erased `{V}` binder. Handled by `lookupCaseArg`, separate from `lookupVar`.

- Remove the scrutinized case argument before compiling constructor branch bodies.
  Agda compiled case branches are checked in an environment where the scrutinized argument has been removed. For `lookup defaultVal key tree = case tree of ...`, branch bodies no longer count `tree` as a normal variable. Without removing it, generated Scala used the wrong variables, e.g. returning `key` instead of `defaultVal`. Handled by `removeCaseArg` before compiling constructor branches.

Tests cover these invariants in `Compile.TermsProps`, including:
```
━━━ Terms / Env / application ━━━
  ✓ function type params stay in Env as erased de Bruijn slots passed 100 tests.
  ✓ case arguments use source-order positions including erased binders passed 100 tests.
  ✓ case branch environment removes the scrutinized argument passed 100 tests.
  ✓ constructor branch binders are added after dropping the case scrutinee passed 100 tests.
```

This unblocked:
* Add example with polymorphic `lookup` in `RedBlackTree`  in and Scala test code to validate

Other changes:
* Fix extra blank lines / missing newlines in Scala2 rendering
* Fix Scala3 indentation for multiline definitions inside objects
* Refactor common rendering code into `CommonTest`