### PR TITLE
Nested constructor patterns - RedBlackTree lookup and insert

### DIFF
--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -66,6 +66,7 @@ library
     , containers            >=0.6.0  && <0.9
     , deepseq               >=1.4.4  && <1.6
     , text                  >=2.0.2  && <2.2
+    , transformers
     , unordered-containers  >=0.2.20 && <0.3
 
   default-language: Haskell2010
@@ -115,6 +116,7 @@ test-suite agda2scala-test
     , base                  >=4.13 && <4.23
     , tasty
     , tasty-hunit
+    , transformers
     , unordered-containers  >=0.2.20  && <0.3
 
 test-suite agda2scala-props
@@ -139,6 +141,7 @@ test-suite agda2scala-props
     , containers            >=0.6.0  && <0.9
     , hedgehog              >=1.4    && <1.8
     , text                  >=2.0.2  && <2.2
+    , transformers
     , unordered-containers  >=0.2.20 && <0.3
 
   ghc-options:      -threaded -rtsopts

--- a/examples/rbt.agda
+++ b/examples/rbt.agda
@@ -3,18 +3,16 @@ module examples.rbt where
 open import Data.Bool using (Bool; true; false; if_then_else_)
 open import Data.Nat using (ℕ; _<ᵇ_)
 
-Key = ℕ
-
 data Color : Set where
   Red Black : Color
 {-# COMPILE AGDA2SCALA Color #-}
 
 data RedBlackTree (V : Set) : Set where
   EmptyRBT : RedBlackTree V
-  RBT      : Color -> RedBlackTree V -> Key -> V -> RedBlackTree V -> RedBlackTree V
+  RBT      : Color -> RedBlackTree V -> ℕ -> V -> RedBlackTree V -> RedBlackTree V
 {-# COMPILE AGDA2SCALA RedBlackTree #-}
 
-lookup : {V : Set} -> V -> Key -> RedBlackTree V -> V
+lookup : {V : Set} -> V -> ℕ -> RedBlackTree V -> V
 lookup defaultVal key EmptyRBT =
   defaultVal
 lookup defaultVal key (RBT c left currKey x right) =
@@ -27,7 +25,7 @@ lookup defaultVal key (RBT c left currKey x right) =
       x
 {-# COMPILE AGDA2SCALA lookup #-}
 
-checkR : {V : Set} -> Key -> RedBlackTree V -> V -> RedBlackTree V -> RedBlackTree V
+checkR : {V : Set} -> ℕ -> RedBlackTree V -> V -> RedBlackTree V -> RedBlackTree V
 checkR k tl vk (RBT Red (RBT Red b y vy tr2) z vz tr3) =
   RBT Red (RBT Black tl k vk b) y vy (RBT Black tr2 z vz tr3)
 checkR k tl vk (RBT Red EmptyRBT y vy (RBT Red tl2 z vz tr2)) =
@@ -38,7 +36,7 @@ checkR k tl vk tr =
   RBT Black tl k vk tr
 {-# COMPILE AGDA2SCALA checkR #-}
 
-checkL : {V : Set} -> Key -> RedBlackTree V -> V -> RedBlackTree V -> RedBlackTree V
+checkL : {V : Set} -> ℕ -> RedBlackTree V -> V -> RedBlackTree V -> RedBlackTree V
 checkL k (RBT Red (RBT Red a x vx b) y vy c) vk tr =
   RBT Red (RBT Black a x vx b) y vy (RBT Black c k vk tr)
 checkL k (RBT Red EmptyRBT x vx (RBT Red b y vy c)) vk tr =
@@ -48,12 +46,12 @@ checkL k (RBT Red (RBT Black a1 x1 vx1 a2) x vx (RBT Red b y vy c)) vk tr =
 checkL k tl vk tr = checkR k tl vk tr
 {-# COMPILE AGDA2SCALA checkL #-}
 
-balance : {V : Set} -> Color -> RedBlackTree V -> Key -> V -> RedBlackTree V -> RedBlackTree V
+balance : {V : Set} -> Color -> RedBlackTree V -> ℕ -> V -> RedBlackTree V -> RedBlackTree V
 balance Red tl k vk tr   = RBT Red tl k vk tr
 balance Black tl k vk tr = checkL k tl vk tr
 {-# COMPILE AGDA2SCALA balance #-}
 
-ins : {V : Set} -> Key -> V -> RedBlackTree V -> RedBlackTree V
+ins : {V : Set} -> ℕ -> V -> RedBlackTree V -> RedBlackTree V
 ins key val EmptyRBT = RBT Red EmptyRBT key val EmptyRBT
 ins key val (RBT c tl k2 v2 tr) =
   if key <ᵇ k2 then
@@ -70,6 +68,6 @@ makeBlack EmptyRBT = EmptyRBT
 makeBlack (RBT c tl k val tr) = RBT Black tl k val tr
 {-# COMPILE AGDA2SCALA makeBlack #-}
 
-insert : {V : Set} -> Key -> V -> RedBlackTree V -> RedBlackTree V
+insert : {V : Set} -> ℕ -> V -> RedBlackTree V -> RedBlackTree V
 insert k val t = makeBlack (ins k val t)
 {-# COMPILE AGDA2SCALA insert #-}

--- a/examples/rbt.agda
+++ b/examples/rbt.agda
@@ -3,16 +3,18 @@ module examples.rbt where
 open import Data.Bool using (Bool; true; false; if_then_else_)
 open import Data.Nat using (ℕ; _<ᵇ_)
 
+Key = ℕ
+
 data Color : Set where
   Red Black : Color
 {-# COMPILE AGDA2SCALA Color #-}
 
 data RedBlackTree (V : Set) : Set where
   EmptyRBT : RedBlackTree V
-  RBT      : Color -> RedBlackTree V -> ℕ -> V -> RedBlackTree V -> RedBlackTree V
+  RBT      : Color -> RedBlackTree V -> Key -> V -> RedBlackTree V -> RedBlackTree V
 {-# COMPILE AGDA2SCALA RedBlackTree #-}
 
-lookup : {V : Set} -> V -> ℕ -> RedBlackTree V -> V
+lookup : {V : Set} -> V -> Key -> RedBlackTree V -> V
 lookup defaultVal key EmptyRBT =
   defaultVal
 lookup defaultVal key (RBT c left currKey x right) =
@@ -24,3 +26,50 @@ lookup defaultVal key (RBT c left currKey x right) =
     else
       x
 {-# COMPILE AGDA2SCALA lookup #-}
+
+checkR : {V : Set} -> Key -> RedBlackTree V -> V -> RedBlackTree V -> RedBlackTree V
+checkR k tl vk (RBT Red (RBT Red b y vy tr2) z vz tr3) =
+  RBT Red (RBT Black tl k vk b) y vy (RBT Black tr2 z vz tr3)
+checkR k tl vk (RBT Red EmptyRBT y vy (RBT Red tl2 z vz tr2)) =
+  RBT Red (RBT Black tl k vk EmptyRBT) y vy (RBT Black tl2 z vz tr2)
+checkR k tl vk (RBT Red (RBT Black b1 y1 vy1 b2) y vy (RBT Red tl2 z vz tr2)) =
+  RBT Red (RBT Black tl k vk (RBT Black b1 y1 vy1 b2)) y vy (RBT Black tl2 z vz tr2)
+checkR k tl vk tr =
+  RBT Black tl k vk tr
+{-# COMPILE AGDA2SCALA checkR #-}
+
+checkL : {V : Set} -> Key -> RedBlackTree V -> V -> RedBlackTree V -> RedBlackTree V
+checkL k (RBT Red (RBT Red a x vx b) y vy c) vk tr =
+  RBT Red (RBT Black a x vx b) y vy (RBT Black c k vk tr)
+checkL k (RBT Red EmptyRBT x vx (RBT Red b y vy c)) vk tr =
+  RBT Red (RBT Black EmptyRBT x vx b) y vy (RBT Black c k vk tr)
+checkL k (RBT Red (RBT Black a1 x1 vx1 a2) x vx (RBT Red b y vy c)) vk tr =
+  RBT Red (RBT Black (RBT Black a1 x1 vx1 a2) x vx b) y vy (RBT Black c k vk tr)
+checkL k tl vk tr = checkR k tl vk tr
+{-# COMPILE AGDA2SCALA checkL #-}
+
+balance : {V : Set} -> Color -> RedBlackTree V -> Key -> V -> RedBlackTree V -> RedBlackTree V
+balance Red tl k vk tr   = RBT Red tl k vk tr
+balance Black tl k vk tr = checkL k tl vk tr
+{-# COMPILE AGDA2SCALA balance #-}
+
+ins : {V : Set} -> Key -> V -> RedBlackTree V -> RedBlackTree V
+ins key val EmptyRBT = RBT Red EmptyRBT key val EmptyRBT
+ins key val (RBT c tl k2 v2 tr) =
+  if key <ᵇ k2 then
+    balance c (ins key val tl) k2 v2 tr
+  else
+    if k2 <ᵇ key then
+      balance c tl k2 v2 (ins key val tr)
+    else
+      RBT c tl key val tr
+{-# COMPILE AGDA2SCALA ins #-}
+
+makeBlack : {V : Set} -> RedBlackTree V -> RedBlackTree V
+makeBlack EmptyRBT = EmptyRBT
+makeBlack (RBT c tl k val tr) = RBT Black tl k val tr
+{-# COMPILE AGDA2SCALA makeBlack #-}
+
+insert : {V : Set} -> Key -> V -> RedBlackTree V -> RedBlackTree V
+insert k val t = makeBlack (ins k val t)
+{-# COMPILE AGDA2SCALA insert #-}

--- a/scala2/src/main/scala/examples/rbt.scala
+++ b/scala2/src/main/scala/examples/rbt.scala
@@ -34,26 +34,40 @@ def checkR[V](x1: Long, x2: RedBlackTree[V], x3: V, x4: RedBlackTree[V]): RedBla
         p1 match {
           case RedBlackTree.EmptyRBT =>
             p4 match {
-              case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+              case RedBlackTree.RBT(p0, p1, p5, p6, p7) =>
                 p0 match {
                   case Color.Red =>
-                    RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.EmptyRBT), p2, p3, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
+                    RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.EmptyRBT), p2, p3, RedBlackTree.RBT(Color.Black, p1, p5, p6, p7))
+                  case _ =>
+                    RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
                 }
+              case _ =>
+                RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
             }
-          case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
-            p2 match {
+          case RedBlackTree.RBT(p0, p5, p6, p7, p8) =>
+            p0 match {
               case Color.Red =>
-                RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, p3), p4, p0, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
+                RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, p5), p6, p7, RedBlackTree.RBT(Color.Black, p8, p2, p3, p4))
               case Color.Black =>
                 p4 match {
-                  case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                  case RedBlackTree.RBT(p0, p1, p9, p10, p11) =>
                     p0 match {
                       case Color.Red =>
-                        RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.RBT(Color.Black, p3, p4, p0, p1)), p2, p3, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
+                        RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8)), p2, p3, RedBlackTree.RBT(Color.Black, p1, p9, p10, p11))
+                      case _ =>
+                        RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
                     }
+                  case _ =>
+                    RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
                 }
+              case _ =>
+                RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
             }
+          case _ =>
+            RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
         }
+      case _ =>
+        RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
     }
   case _ =>
     RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
@@ -61,31 +75,45 @@ def checkR[V](x1: Long, x2: RedBlackTree[V], x3: V, x4: RedBlackTree[V]): RedBla
 
 def checkL[V](x1: Long, x2: RedBlackTree[V], x3: V, x4: RedBlackTree[V]): RedBlackTree[V] = x2 match {
   case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
-    x3 match {
+    p0 match {
       case Color.Red =>
-        x4 match {
+        p1 match {
           case RedBlackTree.EmptyRBT =>
-            p2 match {
-              case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
-                p3 match {
+            p4 match {
+              case RedBlackTree.RBT(p0, p1, p5, p6, p7) =>
+                p0 match {
                   case Color.Red =>
-                    RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.EmptyRBT, p0, p1, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
+                    RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.EmptyRBT, p2, p3, p1), p5, p6, RedBlackTree.RBT(Color.Black, p7, x1, x3, x4))
+                  case _ =>
+                    checkR(x1, x2, x3, x4)
                 }
+              case _ =>
+                checkR(x1, x2, x3, x4)
             }
-          case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+          case RedBlackTree.RBT(p0, p5, p6, p7, p8) =>
             p0 match {
               case Color.Red =>
-                RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
+                RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8), p2, p3, RedBlackTree.RBT(Color.Black, p4, x1, x3, x4))
               case Color.Black =>
-                p2 match {
-                  case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
-                    p3 match {
+                p4 match {
+                  case RedBlackTree.RBT(p0, p1, p9, p10, p11) =>
+                    p0 match {
                       case Color.Red =>
-                        RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4), p0, p1, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
+                        RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8), p2, p3, p1), p9, p10, RedBlackTree.RBT(Color.Black, p11, x1, x3, x4))
+                      case _ =>
+                        checkR(x1, x2, x3, x4)
                     }
+                  case _ =>
+                    checkR(x1, x2, x3, x4)
                 }
+              case _ =>
+                checkR(x1, x2, x3, x4)
             }
+          case _ =>
+            checkR(x1, x2, x3, x4)
         }
+      case _ =>
+        checkR(x1, x2, x3, x4)
     }
   case _ =>
     checkR(x1, x2, x3, x4)

--- a/scala2/src/main/scala/examples/rbt.scala
+++ b/scala2/src/main/scala/examples/rbt.scala
@@ -34,26 +34,26 @@ def checkR[V](x1: Long, x2: RedBlackTree[V], x3: V, x4: RedBlackTree[V]): RedBla
         p1 match {
           case RedBlackTree.EmptyRBT =>
             p4 match {
-              case RedBlackTree.RBT(p0, p1, p5, p6, p7) =>
-                p0 match {
+              case RedBlackTree.RBT(p5, p6, p7, p8, p9) =>
+                p5 match {
                   case Color.Red =>
-                    RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.EmptyRBT), p2, p3, RedBlackTree.RBT(Color.Black, p1, p5, p6, p7))
+                    RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.EmptyRBT), p2, p3, RedBlackTree.RBT(Color.Black, p6, p7, p8, p9))
                   case _ =>
                     RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
                 }
               case _ =>
                 RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
             }
-          case RedBlackTree.RBT(p0, p5, p6, p7, p8) =>
-            p0 match {
+          case RedBlackTree.RBT(p10, p11, p12, p13, p14) =>
+            p10 match {
               case Color.Red =>
-                RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, p5), p6, p7, RedBlackTree.RBT(Color.Black, p8, p2, p3, p4))
+                RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, p11), p12, p13, RedBlackTree.RBT(Color.Black, p14, p2, p3, p4))
               case Color.Black =>
                 p4 match {
-                  case RedBlackTree.RBT(p0, p1, p9, p10, p11) =>
-                    p0 match {
+                  case RedBlackTree.RBT(p15, p16, p17, p18, p19) =>
+                    p15 match {
                       case Color.Red =>
-                        RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8)), p2, p3, RedBlackTree.RBT(Color.Black, p1, p9, p10, p11))
+                        RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.RBT(Color.Black, p11, p12, p13, p14)), p2, p3, RedBlackTree.RBT(Color.Black, p16, p17, p18, p19))
                       case _ =>
                         RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
                     }
@@ -80,26 +80,26 @@ def checkL[V](x1: Long, x2: RedBlackTree[V], x3: V, x4: RedBlackTree[V]): RedBla
         p1 match {
           case RedBlackTree.EmptyRBT =>
             p4 match {
-              case RedBlackTree.RBT(p0, p1, p5, p6, p7) =>
-                p0 match {
+              case RedBlackTree.RBT(p5, p6, p7, p8, p9) =>
+                p5 match {
                   case Color.Red =>
-                    RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.EmptyRBT, p2, p3, p1), p5, p6, RedBlackTree.RBT(Color.Black, p7, x1, x3, x4))
+                    RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.EmptyRBT, p2, p3, p6), p7, p8, RedBlackTree.RBT(Color.Black, p9, x1, x3, x4))
                   case _ =>
                     checkR(x1, x2, x3, x4)
                 }
               case _ =>
                 checkR(x1, x2, x3, x4)
             }
-          case RedBlackTree.RBT(p0, p5, p6, p7, p8) =>
-            p0 match {
+          case RedBlackTree.RBT(p10, p11, p12, p13, p14) =>
+            p10 match {
               case Color.Red =>
-                RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8), p2, p3, RedBlackTree.RBT(Color.Black, p4, x1, x3, x4))
+                RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, p11, p12, p13, p14), p2, p3, RedBlackTree.RBT(Color.Black, p4, x1, x3, x4))
               case Color.Black =>
                 p4 match {
-                  case RedBlackTree.RBT(p0, p1, p9, p10, p11) =>
-                    p0 match {
+                  case RedBlackTree.RBT(p15, p16, p17, p18, p19) =>
+                    p15 match {
                       case Color.Red =>
-                        RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8), p2, p3, p1), p9, p10, RedBlackTree.RBT(Color.Black, p11, x1, x3, x4))
+                        RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.RBT(Color.Black, p11, p12, p13, p14), p2, p3, p16), p17, p18, RedBlackTree.RBT(Color.Black, p19, x1, x3, x4))
                       case _ =>
                         checkR(x1, x2, x3, x4)
                     }

--- a/scala2/src/main/scala/examples/rbt.scala
+++ b/scala2/src/main/scala/examples/rbt.scala
@@ -26,4 +26,96 @@ def lookup[V](x1: V, x2: Long, x3: RedBlackTree[V]): V = x3 match {
     else
       p3
 }
+
+def checkR[V](x1: Long, x2: RedBlackTree[V], x3: V, x4: RedBlackTree[V]): RedBlackTree[V] = x4 match {
+  case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+    p0 match {
+      case Color.Red =>
+        p1 match {
+          case RedBlackTree.EmptyRBT =>
+            p4 match {
+              case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                p0 match {
+                  case Color.Red =>
+                    RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.EmptyRBT), p2, p3, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
+                }
+            }
+          case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+            p2 match {
+              case Color.Red =>
+                RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, p3), p4, p0, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
+              case Color.Black =>
+                p4 match {
+                  case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                    p0 match {
+                      case Color.Red =>
+                        RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.RBT(Color.Black, p3, p4, p0, p1)), p2, p3, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
+                    }
+                }
+            }
+        }
+    }
+  case _ =>
+    RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
+}
+
+def checkL[V](x1: Long, x2: RedBlackTree[V], x3: V, x4: RedBlackTree[V]): RedBlackTree[V] = x2 match {
+  case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+    x3 match {
+      case Color.Red =>
+        x4 match {
+          case RedBlackTree.EmptyRBT =>
+            p2 match {
+              case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                p3 match {
+                  case Color.Red =>
+                    RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.EmptyRBT, p0, p1, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
+                }
+            }
+          case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+            p0 match {
+              case Color.Red =>
+                RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
+              case Color.Black =>
+                p2 match {
+                  case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                    p3 match {
+                      case Color.Red =>
+                        RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4), p0, p1, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
+                    }
+                }
+            }
+        }
+    }
+  case _ =>
+    checkR(x1, x2, x3, x4)
+}
+
+def balance[V](x1: Color, x2: RedBlackTree[V], x3: Long, x4: V, x5: RedBlackTree[V]): RedBlackTree[V] = x1 match {
+  case Color.Red =>
+    RedBlackTree.RBT(Color.Red, x2, x3, x4, x5)
+  case Color.Black =>
+    checkL(x3, x2, x4, x5)
+}
+
+def ins[V](x1: Long, x2: V, x3: RedBlackTree[V]): RedBlackTree[V] = x3 match {
+  case RedBlackTree.EmptyRBT =>
+    RedBlackTree.RBT(Color.Red, RedBlackTree.EmptyRBT, x1, x2, RedBlackTree.EmptyRBT)
+  case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+    if (x1 < p2)
+      balance(p0, ins(x1, x2, p1), p2, p3, p4)
+    else if (p2 < x1)
+      balance(p0, p1, p2, p3, ins(x1, x2, p4))
+    else
+      RedBlackTree.RBT(p0, p1, x1, x2, p4)
+}
+
+def makeBlack[V](x1: RedBlackTree[V]): RedBlackTree[V] = x1 match {
+  case RedBlackTree.EmptyRBT =>
+    RedBlackTree.EmptyRBT
+  case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+    RedBlackTree.RBT(Color.Black, p1, p2, p3, p4)
+}
+
+def insert[V](x1: Long, x2: V, x3: RedBlackTree[V]): RedBlackTree[V] = makeBlack(ins(x1, x2, x3))
 }

--- a/scala2/src/test/scala/examples/RedBlackTreeSpec.scala
+++ b/scala2/src/test/scala/examples/RedBlackTreeSpec.scala
@@ -18,10 +18,11 @@ object RedBlackTreeSpec extends JUnitRunnableSpec {
   def spec = suite("RedBlackTree")(
     test("lookup on empty rbt returns default value") {
       val rbt = emptyRBT[String]
-      val defaultVal = "foo"
+      val defaultVal = "missing"
       val key = 42L
       assertTrue(defaultVal == lookup(defaultVal, key, rbt))
     },
+
     test("lookup returns stored value when key matches root") {
       val rbt =
         RedBlackTree.RBT[String](
@@ -32,7 +33,26 @@ object RedBlackTreeSpec extends JUnitRunnableSpec {
           emptyRBT[String]
         )
 
-      assertTrue(lookup("default", 42L, rbt) == "found")
+      assertTrue(lookup("missing", 42L, rbt) == "found")
+    },
+
+    test("lookup after single insert returns inserted value") {
+      val t1 = insert(42L, "found", emptyRBT[String])
+      assertTrue(lookup("missing", 42L, t1) == "found")
+    },
+
+    test("lookup after several inserts returns matching values") {
+      val t0 = emptyRBT[String]
+      val t1 = insert(10L, "a", t0)
+      val t2 = insert(5L, "b", t1)
+      val t3 = insert(20L, "c", t2)
+
+      assertTrue(
+        lookup("missing", 10L, t3) == "a",
+        lookup("missing", 5L, t3) == "b",
+        lookup("missing", 20L, t3) == "c",
+        lookup("missing", 999L, t3) == "missing"
+      )
     }
   )
 }

--- a/scala3/src/main/scala/examples/rbt.scala
+++ b/scala3/src/main/scala/examples/rbt.scala
@@ -19,3 +19,76 @@ object rbt:
         lookup(x1, x2, p4)
       else
         p3
+
+  def checkR[V](x1: Long, x2: RedBlackTree[V], x3: V, x4: RedBlackTree[V]): RedBlackTree[V] = x4 match
+    case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+      p0 match
+        case Color.Red =>
+          p1 match
+            case RedBlackTree.EmptyRBT =>
+              p4 match
+                case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                  p0 match
+                    case Color.Red =>
+                      RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.EmptyRBT), p2, p3, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
+            case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+              p2 match
+                case Color.Red =>
+                  RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, p3), p4, p0, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
+                case Color.Black =>
+                  p4 match
+                    case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                      p0 match
+                        case Color.Red =>
+                          RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.RBT(Color.Black, p3, p4, p0, p1)), p2, p3, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
+    case _ =>
+      RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
+
+  def checkL[V](x1: Long, x2: RedBlackTree[V], x3: V, x4: RedBlackTree[V]): RedBlackTree[V] = x2 match
+    case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+      x3 match
+        case Color.Red =>
+          x4 match
+            case RedBlackTree.EmptyRBT =>
+              p2 match
+                case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                  p3 match
+                    case Color.Red =>
+                      RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.EmptyRBT, p0, p1, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
+            case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+              p0 match
+                case Color.Red =>
+                  RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
+                case Color.Black =>
+                  p2 match
+                    case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                      p3 match
+                        case Color.Red =>
+                          RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4), p0, p1, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
+    case _ =>
+      checkR(x1, x2, x3, x4)
+
+  def balance[V](x1: Color, x2: RedBlackTree[V], x3: Long, x4: V, x5: RedBlackTree[V]): RedBlackTree[V] = x1 match
+    case Color.Red =>
+      RedBlackTree.RBT(Color.Red, x2, x3, x4, x5)
+    case Color.Black =>
+      checkL(x3, x2, x4, x5)
+
+  def ins[V](x1: Long, x2: V, x3: RedBlackTree[V]): RedBlackTree[V] = x3 match
+    case RedBlackTree.EmptyRBT =>
+      RedBlackTree.RBT(Color.Red, RedBlackTree.EmptyRBT, x1, x2, RedBlackTree.EmptyRBT)
+    case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+      if x1 < p2 then
+        balance(p0, ins(x1, x2, p1), p2, p3, p4)
+      else if p2 < x1 then
+        balance(p0, p1, p2, p3, ins(x1, x2, p4))
+      else
+        RedBlackTree.RBT(p0, p1, x1, x2, p4)
+
+  def makeBlack[V](x1: RedBlackTree[V]): RedBlackTree[V] = x1 match
+    case RedBlackTree.EmptyRBT =>
+      RedBlackTree.EmptyRBT
+    case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+      RedBlackTree.RBT(Color.Black, p1, p2, p3, p4)
+
+  def insert[V](x1: Long, x2: V, x3: RedBlackTree[V]): RedBlackTree[V] = makeBlack(ins(x1, x2, x3))

--- a/scala3/src/main/scala/examples/rbt.scala
+++ b/scala3/src/main/scala/examples/rbt.scala
@@ -27,44 +27,72 @@ object rbt:
           p1 match
             case RedBlackTree.EmptyRBT =>
               p4 match
-                case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                case RedBlackTree.RBT(p0, p1, p5, p6, p7) =>
                   p0 match
                     case Color.Red =>
-                      RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.EmptyRBT), p2, p3, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
-            case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
-              p2 match
+                      RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.EmptyRBT), p2, p3, RedBlackTree.RBT(Color.Black, p1, p5, p6, p7))
+                    case _ =>
+                      RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
+                case _ =>
+                  RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
+            case RedBlackTree.RBT(p0, p5, p6, p7, p8) =>
+              p0 match
                 case Color.Red =>
-                  RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, p3), p4, p0, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
+                  RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, p5), p6, p7, RedBlackTree.RBT(Color.Black, p8, p2, p3, p4))
                 case Color.Black =>
                   p4 match
-                    case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                    case RedBlackTree.RBT(p0, p1, p9, p10, p11) =>
                       p0 match
                         case Color.Red =>
-                          RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.RBT(Color.Black, p3, p4, p0, p1)), p2, p3, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4))
+                          RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8)), p2, p3, RedBlackTree.RBT(Color.Black, p1, p9, p10, p11))
+                        case _ =>
+                          RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
+                    case _ =>
+                      RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
+                case _ =>
+                  RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
+            case _ =>
+              RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
+        case _ =>
+          RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
     case _ =>
       RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
 
   def checkL[V](x1: Long, x2: RedBlackTree[V], x3: V, x4: RedBlackTree[V]): RedBlackTree[V] = x2 match
     case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
-      x3 match
+      p0 match
         case Color.Red =>
-          x4 match
+          p1 match
             case RedBlackTree.EmptyRBT =>
-              p2 match
-                case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
-                  p3 match
+              p4 match
+                case RedBlackTree.RBT(p0, p1, p5, p6, p7) =>
+                  p0 match
                     case Color.Red =>
-                      RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.EmptyRBT, p0, p1, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
-            case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
+                      RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.EmptyRBT, p2, p3, p1), p5, p6, RedBlackTree.RBT(Color.Black, p7, x1, x3, x4))
+                    case _ =>
+                      checkR(x1, x2, x3, x4)
+                case _ =>
+                  checkR(x1, x2, x3, x4)
+            case RedBlackTree.RBT(p0, p5, p6, p7, p8) =>
               p0 match
                 case Color.Red =>
-                  RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
+                  RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8), p2, p3, RedBlackTree.RBT(Color.Black, p4, x1, x3, x4))
                 case Color.Black =>
-                  p2 match
-                    case RedBlackTree.RBT(p0, p1, p2, p3, p4) =>
-                      p3 match
+                  p4 match
+                    case RedBlackTree.RBT(p0, p1, p9, p10, p11) =>
+                      p0 match
                         case Color.Red =>
-                          RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.RBT(Color.Black, p1, p2, p3, p4), p0, p1, p4), p0, p1, RedBlackTree.RBT(Color.Black, p2, x1, p3, p4))
+                          RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8), p2, p3, p1), p9, p10, RedBlackTree.RBT(Color.Black, p11, x1, x3, x4))
+                        case _ =>
+                          checkR(x1, x2, x3, x4)
+                    case _ =>
+                      checkR(x1, x2, x3, x4)
+                case _ =>
+                  checkR(x1, x2, x3, x4)
+            case _ =>
+              checkR(x1, x2, x3, x4)
+        case _ =>
+          checkR(x1, x2, x3, x4)
     case _ =>
       checkR(x1, x2, x3, x4)
 

--- a/scala3/src/main/scala/examples/rbt.scala
+++ b/scala3/src/main/scala/examples/rbt.scala
@@ -27,24 +27,24 @@ object rbt:
           p1 match
             case RedBlackTree.EmptyRBT =>
               p4 match
-                case RedBlackTree.RBT(p0, p1, p5, p6, p7) =>
-                  p0 match
+                case RedBlackTree.RBT(p5, p6, p7, p8, p9) =>
+                  p5 match
                     case Color.Red =>
-                      RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.EmptyRBT), p2, p3, RedBlackTree.RBT(Color.Black, p1, p5, p6, p7))
+                      RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.EmptyRBT), p2, p3, RedBlackTree.RBT(Color.Black, p6, p7, p8, p9))
                     case _ =>
                       RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
                 case _ =>
                   RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
-            case RedBlackTree.RBT(p0, p5, p6, p7, p8) =>
-              p0 match
+            case RedBlackTree.RBT(p10, p11, p12, p13, p14) =>
+              p10 match
                 case Color.Red =>
-                  RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, p5), p6, p7, RedBlackTree.RBT(Color.Black, p8, p2, p3, p4))
+                  RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, p11), p12, p13, RedBlackTree.RBT(Color.Black, p14, p2, p3, p4))
                 case Color.Black =>
                   p4 match
-                    case RedBlackTree.RBT(p0, p1, p9, p10, p11) =>
-                      p0 match
+                    case RedBlackTree.RBT(p15, p16, p17, p18, p19) =>
+                      p15 match
                         case Color.Red =>
-                          RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8)), p2, p3, RedBlackTree.RBT(Color.Black, p1, p9, p10, p11))
+                          RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, x2, x1, x3, RedBlackTree.RBT(Color.Black, p11, p12, p13, p14)), p2, p3, RedBlackTree.RBT(Color.Black, p16, p17, p18, p19))
                         case _ =>
                           RedBlackTree.RBT(Color.Black, x2, x1, x3, x4)
                     case _ =>
@@ -65,24 +65,24 @@ object rbt:
           p1 match
             case RedBlackTree.EmptyRBT =>
               p4 match
-                case RedBlackTree.RBT(p0, p1, p5, p6, p7) =>
-                  p0 match
+                case RedBlackTree.RBT(p5, p6, p7, p8, p9) =>
+                  p5 match
                     case Color.Red =>
-                      RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.EmptyRBT, p2, p3, p1), p5, p6, RedBlackTree.RBT(Color.Black, p7, x1, x3, x4))
+                      RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.EmptyRBT, p2, p3, p6), p7, p8, RedBlackTree.RBT(Color.Black, p9, x1, x3, x4))
                     case _ =>
                       checkR(x1, x2, x3, x4)
                 case _ =>
                   checkR(x1, x2, x3, x4)
-            case RedBlackTree.RBT(p0, p5, p6, p7, p8) =>
-              p0 match
+            case RedBlackTree.RBT(p10, p11, p12, p13, p14) =>
+              p10 match
                 case Color.Red =>
-                  RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8), p2, p3, RedBlackTree.RBT(Color.Black, p4, x1, x3, x4))
+                  RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, p11, p12, p13, p14), p2, p3, RedBlackTree.RBT(Color.Black, p4, x1, x3, x4))
                 case Color.Black =>
                   p4 match
-                    case RedBlackTree.RBT(p0, p1, p9, p10, p11) =>
-                      p0 match
+                    case RedBlackTree.RBT(p15, p16, p17, p18, p19) =>
+                      p15 match
                         case Color.Red =>
-                          RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.RBT(Color.Black, p5, p6, p7, p8), p2, p3, p1), p9, p10, RedBlackTree.RBT(Color.Black, p11, x1, x3, x4))
+                          RedBlackTree.RBT(Color.Red, RedBlackTree.RBT(Color.Black, RedBlackTree.RBT(Color.Black, p11, p12, p13, p14), p2, p3, p16), p17, p18, RedBlackTree.RBT(Color.Black, p19, x1, x3, x4))
                         case _ =>
                           checkR(x1, x2, x3, x4)
                     case _ =>

--- a/scala3/src/test/scala/examples/RedBlackTreeSpec.scala
+++ b/scala3/src/test/scala/examples/RedBlackTreeSpec.scala
@@ -6,7 +6,7 @@ import zio.test.assertTrue
 import examples.rbt.RedBlackTree
 import examples.rbt.Color
 import examples.rbt.RedBlackTree.EmptyRBT
-import examples.rbt.lookup
+import examples.rbt.{insert, lookup}
 
 object RedBlackTreeSpec extends JUnitRunnableSpec:
 
@@ -22,6 +22,7 @@ object RedBlackTreeSpec extends JUnitRunnableSpec:
       val key = 42L
       assertTrue(defaultVal == lookup(defaultVal, key, rbt))
     },
+
     test("lookup returns stored value when key matches root") {
       val rbt =
         RedBlackTree.RBT[String](
@@ -32,5 +33,24 @@ object RedBlackTreeSpec extends JUnitRunnableSpec:
           emptyRBT[String]
         )
       assertTrue(lookup("default", 42L, rbt) == "found")
+    },
+
+    test("lookup after single insert returns inserted value") {
+      val t1 = insert(42L, "found", emptyRBT[String])
+      assertTrue(lookup("missing", 42L, t1) == "found")
+    },
+
+    test("lookup after several inserts returns matching values") {
+      val t0 = emptyRBT[String]
+      val t1 = insert(10L, "a", t0)
+      val t2 = insert(5L, "b", t1)
+      val t3 = insert(20L, "c", t2)
+
+      assertTrue(
+        lookup("missing", 10L, t3) == "a",
+        lookup("missing", 5L, t3) == "b",
+        lookup("missing", 20L, t3) == "c",
+        lookup("missing", 999L, t3) == "missing"
+      )
     }
   )

--- a/src/Agda/Compiler/Scala/Compile/Terms.hs
+++ b/src/Agda/Compiler/Scala/Compile/Terms.hs
@@ -6,6 +6,7 @@ module Agda.Compiler.Scala.Compile.Terms
   , compileFunctionBody
   , envFromArgs
   , envFromFunction
+  , envNames
   , extendEnv
   , freshPatVars
   , lookupVar
@@ -14,11 +15,15 @@ module Agda.Compiler.Scala.Compile.Terms
   , replaceCaseArg
 ) where
 
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State.Strict
+  ( StateT
+  , evalStateT
+  , state
+  )
 import Data.Maybe (catMaybes)
 --import Debug.Trace (trace) -- TODO #72
 import qualified Data.Map as Map
-import qualified Data.Set as Set
-import qualified Data.HashSet as HS
 import Agda.Syntax.Abstract.Name ( QName )
 import Agda.Syntax.Common
   ( Arg(..)
@@ -39,13 +44,22 @@ import Agda.Compiler.Scala.Compile.Types
   ( CompileError (..)
   , CaseUnsupported (..)
   , fromQName)
-import Agda.Compiler.Scala.Name.NameEnv ( freshNumberedNamesAvoiding  )
+import Agda.Compiler.Scala.Name.NameEnv
+  ( FreshNameSupply
+  , freshNameSupplyFrom
+  , takeFreshNumberedNames
+  )
 import Agda.Compiler.Scala.Name.NamePolicy (ctorName, defaultNamePolicy, termName)
 import Agda.Compiler.Scala.IR.ScalaExpr
   ( ScalaName
   , ScalaPat(..)
   , ScalaTerm(..)
   )
+
+type CompileCaseM = StateT FreshNameSupply (Either CompileError)
+
+liftCompile :: Either CompileError a -> CompileCaseM a
+liftCompile = lift
 
 -- ===== Environment ===========================================================
 --
@@ -140,57 +154,70 @@ compileFunctionBody
   -> Maybe CompiledClauses
   -> Either CompileError ScalaTerm
 compileFunctionBody _tyParams _argNames Nothing = Left UnsupportedCompiledClauses
-compileFunctionBody tyParams argNames (Just cc) = compileCompiledClauses Nothing (envFromFunction tyParams argNames) cc
+compileFunctionBody tyParams argNames (Just clauses) =
+  evalStateT
+    (compileCompiledClauses Nothing env clauses)
+    (freshNameSupplyFrom (envNames env))
+  where
+    env = envFromFunction tyParams argNames
 
 -- The optional ScalaTerm is the catch-all inherited from an enclosing case.
 compileCompiledClauses
   :: Maybe ScalaTerm
   -> Env
   -> CompiledClauses
-  -> Either CompileError ScalaTerm
-compileCompiledClauses inheritedFallback env = \case
-  Done _ term -> compileBodyTerm env term
-  Fail _ ->
-    case inheritedFallback of
-      Just fallback -> Right fallback
-      Nothing       -> Left UnsupportedCompiledClauses
-  Case arg branches -> do
-    validateCaseShape branches
-    let caseIndex = unArg arg
-    scrut <- STeVar <$> lookupCaseArg env caseIndex
-    caseFallback <-
-      case catchallBranch branches of
-        Nothing ->
-          Right inheritedFallback
-        Just catchallClauses ->
-          Just <$> compileCompiledClauses inheritedFallback env catchallClauses
-    constructorAlts <-
-      traverse
-        (compileConBranch caseFallback)
-        (Map.toList (conBranches branches))
-    let fallbackAlts =
-          case caseFallback of
-            Nothing       -> []
-            Just fallback -> [(SPWild, fallback)]
-    pure (STeMatch scrut (constructorAlts <> fallbackAlts))
-    where
-      compileConBranch
-        :: Maybe ScalaTerm
-        -> (QName, WithArity CompiledClauses)
-        -> Either CompileError (ScalaPat, ScalaTerm)
-      compileConBranch fallback (conQName, WithArity arityN cc) = do
-        let patVars = freshPatVars env arityN
-            pat = SPCtor (fromQName conQName) (map SPVar patVars)
-        branchEnv <- replaceCaseArg env (unArg arg) patVars
-        rhs <- compileCompiledClauses fallback branchEnv cc
-        pure (pat, rhs)
+  -> CompileCaseM ScalaTerm
+compileCompiledClauses inheritedFallback env clauses =
+  case clauses of
+    Done _ term -> liftCompile (compileBodyTerm env term)
+    Fail _ ->
+      case inheritedFallback of
+        Just fallback -> pure fallback
+        Nothing -> liftCompile (Left UnsupportedCompiledClauses)
+    Case arg branches -> do
+      liftCompile (validateCaseShape branches)
+      let caseIndex = unArg arg
+      scrutinee <- STeVar <$> liftCompile (lookupCaseArg env caseIndex)
+      caseFallback <-
+        case catchallBranch branches of
+          Nothing -> pure inheritedFallback
+          Just catchallClauses ->
+            Just
+              <$> compileCompiledClauses
+                    inheritedFallback
+                    env
+                    catchallClauses
+      constructorAlternatives <-
+        traverse
+          (compileConstructorBranch caseIndex caseFallback env)
+          (Map.toList (conBranches branches))
+      let fallbackAlternatives =
+            case caseFallback of
+              Nothing -> []
+              Just fallback -> [(SPWild, fallback)]
+      pure (STeMatch scrutinee (constructorAlternatives <> fallbackAlternatives))
+--    _ -> liftCompile (Left UnsupportedCompiledClauses)
 
-envNames :: Env -> HS.HashSet ScalaName
-envNames (Env slots) = HS.fromList (catMaybes slots)
+
+compileConstructorBranch
+  :: Int
+  -> Maybe ScalaTerm
+  -> Env
+  -> (QName, WithArity CompiledClauses)
+  -> CompileCaseM (ScalaPat, ScalaTerm)
+compileConstructorBranch caseIndex fallback env
+  (conQName, WithArity arityN clauses) = do
+    patVars <- freshPatVars arityN
+    branchEnv <- liftCompile (replaceCaseArg env caseIndex patVars)
+    rhs <- compileCompiledClauses fallback branchEnv clauses
+    pure (SPCtor (fromQName conQName) (map SPVar patVars), rhs)
+
+envNames :: Env -> [ScalaName]
+envNames (Env slots) = catMaybes slots
 
 -- constructor fields use prefix p
-freshPatVars :: Env -> Int -> [ScalaName]
-freshPatVars env = freshNumberedNamesAvoiding (envNames env) "p"
+freshPatVars :: Int -> CompileCaseM [ScalaName]
+freshPatVars arityN = state (takeFreshNumberedNames "p" arityN)
 
 -- Reject unsupported case-tree shapes explicitly.
 -- Silent branch dropping would generate partial Scala matches.

--- a/src/Agda/Compiler/Scala/Compile/Terms.hs
+++ b/src/Agda/Compiler/Scala/Compile/Terms.hs
@@ -12,7 +12,7 @@ module Agda.Compiler.Scala.Compile.Terms
   , compileBodyTerm
 ) where
 
-import Data.Maybe (catMaybes, fromMaybe, isJust)
+import Data.Maybe (catMaybes, fromMaybe, maybeToList)
 --import Debug.Trace (trace) -- TODO #72
 import qualified Data.Map as Map
 import Agda.Syntax.Abstract.Name ( QName )
@@ -133,24 +133,37 @@ compileCompiledClauses :: Env -> CompiledClauses -> Either CompileError ScalaTer
 compileCompiledClauses env = \case
     Done _ term -> compileBodyTerm env term
     Case arg branches -> do
-      let n = (unArg arg)
+      let n = unArg arg
       scrut <- STeVar <$> lookupCaseArg env n
-      branchEnv <- removeCaseArg env n
-      alts <- compileBranches branchEnv branches
+      constructorEnv <- removeCaseArg env n
+      alts <- compileBranches env constructorEnv branches
       pure (STeMatch scrut alts)
     _ -> Left UnsupportedCompiledClauses
 
-compileBranches :: Env -> Case CompiledClauses -> Either CompileError [(ScalaPat, ScalaTerm)]
-compileBranches env branches = do
+-- Constructor branches replace the scrutinized argument with constructor
+-- fields, so they use constructorEnv.
+--
+-- A catch-all branch does not destructure the argument and its RHS can still
+-- reference that value, so it must use catchallEnv.
+compileBranches :: Env
+ -> Env
+ -> Case CompiledClauses
+ -> Either CompileError [(ScalaPat, ScalaTerm)]
+compileBranches catchallEnv constructorEnv branches = do
     validateCaseShape branches
-    traverse compileConBranch (Map.toList (conBranches branches))
+    constructorAlts <- traverse compileConBranch (Map.toList (conBranches branches))
+    catchallAlt <- traverse compileCatchallBranch (catchallBranch branches)
+    pure (constructorAlts <> maybeToList catchallAlt)
   where
     compileConBranch (conQName, WithArity arityN cc) = do
       let patVars = freshPatVars arityN
           pat     = SPCtor (fromQName conQName) (map SPVar patVars)
-          env'    = extendEnv patVars env
-      rhs <- compileCompiledClauses env' cc
+          env     = extendEnv patVars constructorEnv
+      rhs <- compileCompiledClauses env cc
       pure (pat, rhs)
+    compileCatchallBranch cc = do
+      rhs <- compileCompiledClauses catchallEnv cc
+      pure (SPWild, rhs)
 
 freshPatVars :: Int -> [ScalaName]
 freshPatVars arityN = [ "p" <> show i | i <- [0 .. arityN - 1] ]
@@ -161,7 +174,6 @@ validateCaseShape :: Case CompiledClauses -> Either CompileError ()
 validateCaseShape branches
     | projPatterns branches                  = Left $ UnsupportedCaseShape HasProjectionPatterns
     | not (Map.null (litBranches branches))  = Left $ UnsupportedCaseShape HasLiteralBranches
-    | isJust (catchallBranch branches)       = Left $ UnsupportedCaseShape HasCatchAllBranch
     | fromMaybe False (fallThrough branches) = Left $ UnsupportedCaseShape HasFallThrough
     | otherwise                              = Right ()
 

--- a/src/Agda/Compiler/Scala/Compile/Terms.hs
+++ b/src/Agda/Compiler/Scala/Compile/Terms.hs
@@ -18,6 +18,7 @@ import Data.Maybe (catMaybes)
 --import Debug.Trace (trace) -- TODO #72
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified Data.HashSet as HS
 import Agda.Syntax.Abstract.Name ( QName )
 import Agda.Syntax.Common
   ( Arg(..)
@@ -38,6 +39,7 @@ import Agda.Compiler.Scala.Compile.Types
   ( CompileError (..)
   , CaseUnsupported (..)
   , fromQName)
+import Agda.Compiler.Scala.Name.NameEnv ( freshNumberedNamesAvoiding  )
 import Agda.Compiler.Scala.Name.NamePolicy (ctorName, defaultNamePolicy, termName)
 import Agda.Compiler.Scala.IR.ScalaExpr
   ( ScalaName
@@ -183,11 +185,12 @@ compileCompiledClauses inheritedFallback env = \case
         rhs <- compileCompiledClauses fallback branchEnv cc
         pure (pat, rhs)
 
+envNames :: Env -> HS.HashSet ScalaName
+envNames (Env slots) = HS.fromList (catMaybes slots)
+
+-- constructor fields use prefix p
 freshPatVars :: Env -> Int -> [ScalaName]
-freshPatVars (Env xs) arityN =
-  take arityN [name | i <- [0 :: Int ..], let name = "p" <> show i, name `Set.notMember` used]
-  where
-    used = Set.fromList (catMaybes xs)
+freshPatVars env = freshNumberedNamesAvoiding (envNames env) "p"
 
 -- Reject unsupported case-tree shapes explicitly.
 -- Silent branch dropping would generate partial Scala matches.

--- a/src/Agda/Compiler/Scala/Compile/Terms.hs
+++ b/src/Agda/Compiler/Scala/Compile/Terms.hs
@@ -2,19 +2,22 @@
 
 module Agda.Compiler.Scala.Compile.Terms
   ( Env (..)
+  , compileBodyTerm
+  , compileFunctionBody
   , envFromArgs
   , envFromFunction
   , extendEnv
+  , freshPatVars
   , lookupVar
   , lookupCaseArg
   , removeCaseArg
-  , compileFunctionBody
-  , compileBodyTerm
+  , replaceCaseArg
 ) where
 
-import Data.Maybe (catMaybes, fromMaybe, maybeToList)
+import Data.Maybe (catMaybes)
 --import Debug.Trace (trace) -- TODO #72
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import Agda.Syntax.Abstract.Name ( QName )
 import Agda.Syntax.Common
   ( Arg(..)
@@ -96,9 +99,11 @@ lookupVar (Env xs) i = case drop i xs of
 
 -- Agda uses two index conventions here.
 --
---  Var i   uses de Bruijn order: newest binder first.
---  Case i  uses function-argument order: left-to-right, including erased binders.
---  Case branch bodies are compiled after removing the scrutinized argument.
+--   Var i  uses de Bruijn order: newest binder first.
+--   Case i identifies an argument in the current source-order context.
+--
+-- A constructor branch replaces the scrutinized argument with constructor
+-- fields at the same source-order position. A catch-all retains the argument.
 lookupCaseArg :: Env -> Int -> Either CompileError ScalaName
 lookupCaseArg (Env xs) i =
     case drop i (reverse xs) of
@@ -106,76 +111,91 @@ lookupCaseArg (Env xs) i =
         Nothing : _   -> Left (ErasedVarReferenced i)
         []            -> Left (VarOutOfRange i (length xs))
 
--- removes by Case/source-order index, not by de Bruijn index
+-- Replace the scrutinized argument, identified in source-order Case indexing,
+-- with constructor fields in their source order.
+replaceCaseArg
+  :: Env
+  -> Int
+  -> [ScalaName]
+  -> Either CompileError Env
+replaceCaseArg (Env xs) i names =
+  case splitAt i (reverse xs) of
+    (before, Just _ : after) ->
+      Right (Env (reverse (before <> map Just names <> after)))
+    (_before, Nothing : _after) ->
+      Left (ErasedVarReferenced i)
+    _ ->
+      Left (VarOutOfRange i (length xs))
+
 removeCaseArg :: Env -> Int -> Either CompileError Env
-removeCaseArg (Env xs) i =
-    case splitAt i (reverse xs) of
-        (before, Just _ : after) ->
-            Right (Env (reverse (before <> after)))
-        (_before, Nothing : _after) ->
-            Left (ErasedVarReferenced i)
-        _ ->
-            Left (VarOutOfRange i (length xs))
+removeCaseArg env i = replaceCaseArg env i []
 
 -- ===== Function bodies =======================================================
 
--- Function bodies are read from `CompiledClauses`, not from surface syntax.
--- Pattern matching therefore appears as Agda's compiled case tree.
 compileFunctionBody
-  :: [ScalaName] -- erased type parameters
-  -> [ScalaName] -- runtime term parameters
+  :: [ScalaName]
+  -> [ScalaName]
   -> Maybe CompiledClauses
   -> Either CompileError ScalaTerm
 compileFunctionBody _tyParams _argNames Nothing = Left UnsupportedCompiledClauses
-compileFunctionBody tyParams argNames (Just cc) = compileCompiledClauses (envFromFunction tyParams argNames) cc
+compileFunctionBody tyParams argNames (Just cc) = compileCompiledClauses Nothing (envFromFunction tyParams argNames) cc
 
-compileCompiledClauses :: Env -> CompiledClauses -> Either CompileError ScalaTerm
-compileCompiledClauses env = \case
-    Done _ term -> compileBodyTerm env term
-    Case arg branches -> do
-      let n = unArg arg
-      scrut <- STeVar <$> lookupCaseArg env n
-      constructorEnv <- removeCaseArg env n
-      alts <- compileBranches env constructorEnv branches
-      pure (STeMatch scrut alts)
-    _ -> Left UnsupportedCompiledClauses
-
--- Constructor branches replace the scrutinized argument with constructor
--- fields, so they use constructorEnv.
---
--- A catch-all branch does not destructure the argument and its RHS can still
--- reference that value, so it must use catchallEnv.
-compileBranches :: Env
- -> Env
- -> Case CompiledClauses
- -> Either CompileError [(ScalaPat, ScalaTerm)]
-compileBranches catchallEnv constructorEnv branches = do
+-- The optional ScalaTerm is the catch-all inherited from an enclosing case.
+compileCompiledClauses
+  :: Maybe ScalaTerm
+  -> Env
+  -> CompiledClauses
+  -> Either CompileError ScalaTerm
+compileCompiledClauses inheritedFallback env = \case
+  Done _ term -> compileBodyTerm env term
+  Fail _ ->
+    case inheritedFallback of
+      Just fallback -> Right fallback
+      Nothing       -> Left UnsupportedCompiledClauses
+  Case arg branches -> do
     validateCaseShape branches
-    constructorAlts <- traverse compileConBranch (Map.toList (conBranches branches))
-    catchallAlt <- traverse compileCatchallBranch (catchallBranch branches)
-    pure (constructorAlts <> maybeToList catchallAlt)
-  where
-    compileConBranch (conQName, WithArity arityN cc) = do
-      let patVars = freshPatVars arityN
-          pat     = SPCtor (fromQName conQName) (map SPVar patVars)
-          env     = extendEnv patVars constructorEnv
-      rhs <- compileCompiledClauses env cc
-      pure (pat, rhs)
-    compileCatchallBranch cc = do
-      rhs <- compileCompiledClauses catchallEnv cc
-      pure (SPWild, rhs)
+    let caseIndex = unArg arg
+    scrut <- STeVar <$> lookupCaseArg env caseIndex
+    caseFallback <-
+      case catchallBranch branches of
+        Nothing ->
+          Right inheritedFallback
+        Just catchallClauses ->
+          Just <$> compileCompiledClauses inheritedFallback env catchallClauses
+    constructorAlts <-
+      traverse
+        (compileConBranch caseFallback)
+        (Map.toList (conBranches branches))
+    let fallbackAlts =
+          case caseFallback of
+            Nothing       -> []
+            Just fallback -> [(SPWild, fallback)]
+    pure (STeMatch scrut (constructorAlts <> fallbackAlts))
+    where
+      compileConBranch
+        :: Maybe ScalaTerm
+        -> (QName, WithArity CompiledClauses)
+        -> Either CompileError (ScalaPat, ScalaTerm)
+      compileConBranch fallback (conQName, WithArity arityN cc) = do
+        let patVars = freshPatVars env arityN
+            pat = SPCtor (fromQName conQName) (map SPVar patVars)
+        branchEnv <- replaceCaseArg env (unArg arg) patVars
+        rhs <- compileCompiledClauses fallback branchEnv cc
+        pure (pat, rhs)
 
-freshPatVars :: Int -> [ScalaName]
-freshPatVars arityN = [ "p" <> show i | i <- [0 .. arityN - 1] ]
+freshPatVars :: Env -> Int -> [ScalaName]
+freshPatVars (Env xs) arityN =
+  take arityN [name | i <- [0 :: Int ..], let name = "p" <> show i, name `Set.notMember` used]
+  where
+    used = Set.fromList (catMaybes xs)
 
 -- Reject unsupported case-tree shapes explicitly.
 -- Silent branch dropping would generate partial Scala matches.
 validateCaseShape :: Case CompiledClauses -> Either CompileError ()
 validateCaseShape branches
-    | projPatterns branches                  = Left $ UnsupportedCaseShape HasProjectionPatterns
-    | not (Map.null (litBranches branches))  = Left $ UnsupportedCaseShape HasLiteralBranches
-    | fromMaybe False (fallThrough branches) = Left $ UnsupportedCaseShape HasFallThrough
-    | otherwise                              = Right ()
+  | projPatterns branches                 = Left (UnsupportedCaseShape HasProjectionPatterns)
+  | not (Map.null (litBranches branches)) = Left (UnsupportedCaseShape HasLiteralBranches)
+  | otherwise                             = Right ()
 
 -- ===== Terms ================================================================
 

--- a/src/Agda/Compiler/Scala/Compile/Types.hs
+++ b/src/Agda/Compiler/Scala/Compile/Types.hs
@@ -64,7 +64,6 @@ data CompileError
 
 data CaseUnsupported
   = HasLiteralBranches
-  | HasCatchAllBranch
   | HasFallThrough
   | HasProjectionPatterns
   deriving (Eq, Show)

--- a/src/Agda/Compiler/Scala/Name/NameEnv.hs
+++ b/src/Agda/Compiler/Scala/Name/NameEnv.hs
@@ -1,13 +1,16 @@
 module Agda.Compiler.Scala.Name.NameEnv
-    ( NameEnv (..)
+    ( FreshNameSupply
+    , NameEnv (..)
     , allocFreshLocal
     , allocQName
     , emptyNameEnv
+    , freshNameSupplyFrom
     , freshNumberedNamesAvoiding
     , lookupCtorOwner
     , registerCtors
     , sanitizeScalaIdent
     , scalaKeywords
+    , takeFreshNumberedNames
 ) where
 
 import qualified Data.Char as Char
@@ -130,6 +133,39 @@ freshCandidate base index
     | index == 0 = base
     | otherwise = base <> "_" <> show index
 
+data FreshNameSupply = FreshNameSupply
+  { fnsTaken :: HashSet ScalaName
+  , fnsNextIndex :: Int
+  }
+  deriving (Eq, Show)
+
+freshNameSupplyFrom :: [ScalaName] -> FreshNameSupply
+freshNameSupplyFrom names =
+  FreshNameSupply
+    { fnsTaken = HS.fromList names
+    , fnsNextIndex = 0
+    }
+
+takeFreshNumberedNames
+  :: ScalaName
+  -> Int
+  -> FreshNameSupply
+  -> ([ScalaName], FreshNameSupply)
+takeFreshNumberedNames prefix count supply0 =
+  go count supply0 []
+  where
+    go remaining supply acc
+      | remaining <= 0 = (reverse acc, supply)
+      | otherwise =
+          let index = fnsNextIndex supply
+              candidate = sanitizeScalaIdent (prefix <> show index)
+              advanced = supply { fnsNextIndex = index + 1 }
+           in if candidate `HS.member` fnsTaken supply
+                then go remaining advanced acc
+                else
+                  let allocated = advanced { fnsTaken = HS.insert candidate (fnsTaken advanced) }
+                   in go (remaining - 1) allocated (candidate : acc)
+
 freshNumberedNamesAvoiding
   :: HashSet ScalaName
   -> ScalaName
@@ -137,11 +173,11 @@ freshNumberedNamesAvoiding
   -> [ScalaName]
 freshNumberedNamesAvoiding taken prefix count =
   take count
-    [ candidate | i <- [0 :: Int ..]
+    [ candidate
+    | i <- [0 :: Int ..]
     , let candidate = sanitizeScalaIdent (prefix <> show i)
-    , candidate `notMember` taken ]
-
-notMember a xs = not (a `HS.member` xs)
+    , not (candidate `HS.member` taken)
+    ]
 
 allocQName :: NameEnv -> QName -> String -> (NameEnv, ScalaName)
 allocQName ne qn suggestedBase =

--- a/src/Agda/Compiler/Scala/Name/NameEnv.hs
+++ b/src/Agda/Compiler/Scala/Name/NameEnv.hs
@@ -1,12 +1,13 @@
-module Agda.Compiler.Scala.Name.NameEnv (
-    NameEnv (..),
-    emptyNameEnv,
-    sanitizeScalaIdent,
-    scalaKeywords,
-    allocFreshLocal,
-    allocQName,
-    registerCtors,
-    lookupCtorOwner,
+module Agda.Compiler.Scala.Name.NameEnv
+    ( NameEnv (..)
+    , allocFreshLocal
+    , allocQName
+    , emptyNameEnv
+    , freshNumberedNamesAvoiding
+    , lookupCtorOwner
+    , registerCtors
+    , sanitizeScalaIdent
+    , scalaKeywords
 ) where
 
 import qualified Data.Char as Char
@@ -128,6 +129,19 @@ freshCandidate :: ScalaName -> Int -> ScalaName
 freshCandidate base index
     | index == 0 = base
     | otherwise = base <> "_" <> show index
+
+freshNumberedNamesAvoiding
+  :: HashSet ScalaName
+  -> ScalaName
+  -> Int
+  -> [ScalaName]
+freshNumberedNamesAvoiding taken prefix count =
+  take count
+    [ candidate | i <- [0 :: Int ..]
+    , let candidate = sanitizeScalaIdent (prefix <> show i)
+    , candidate `notMember` taken ]
+
+notMember a xs = not (a `HS.member` xs)
 
 allocQName :: NameEnv -> QName -> String -> (NameEnv, ScalaName)
 allocQName ne qn suggestedBase =

--- a/test/Compile/TermsProps.hs
+++ b/test/Compile/TermsProps.hs
@@ -26,9 +26,11 @@ import Agda.Compiler.Scala.Compile.Terms
   , envFromArgs
   , envFromFunction
   , extendEnv
+  , freshPatVars
   , lookupCaseArg
   , lookupVar
   , removeCaseArg
+  , replaceCaseArg
   )
 import Agda.Compiler.Scala.Compile (compileBodyTerm)
 import Agda.Compiler.Scala.Compile.Types (CompileError(..))
@@ -48,6 +50,10 @@ termsProps =
     , ("case branch environment removes the scrutinized argument", prop_removeCaseArg_dropsScrutinee)
     , ("constructor branch binders are added after dropping the case scrutinee", prop_caseBranchEnv_addsPatternBindersAfterDroppingScrutinee)
     , ("catch-all branches retain the scrutinized runtime argument", prop_catchallBranch_retainsScrutinee)
+    , ("constructor fields replace the scrutinized argument at its source position", prop_replaceCaseArg_preservesSourcePosition)
+    , ("constructor fields replace the scrutinized slot in source order", prop_replaceCaseArg_matchesSourceOrderModel)
+    , ("fresh pattern variables are unique and avoid names already in scope", prop_freshPatVars_avoidsNestedShadowing)
+    , ("replaceCaseArg makes fields addressable in source order", prop_replaceCaseArg_makesFieldsAddressableInSourceOrder)
     ]
 
 mkApply :: Term -> Elim' Term
@@ -220,3 +226,64 @@ prop_catchallBranch_retainsScrutinee = property $ do
 
     compileFunctionBody tyParams args (Just clauses) === Right expected
 
+prop_replaceCaseArg_preservesSourcePosition :: Property
+prop_replaceCaseArg_preservesSourcePosition = property $ do
+  let env      = Env [ Just "d", Just "c", Just "b", Just "a" ]
+      expected = Env [ Just "d", Just "f", Just "e", Just "b", Just "a" ]
+  replaceCaseArg env 2 ["e", "f"] === Right expected
+
+prop_freshPatVars_avoidsNestedShadowing :: Property
+prop_freshPatVars_avoidsNestedShadowing = property $ do
+  let env =
+        Env
+          [ Just "p4"
+          , Just "p3"
+          , Just "p2"
+          , Just "p1"
+          , Just "p0"
+          ]
+  freshPatVars env 3 === ["p5", "p6", "p7"]
+
+-- replaceCaseArg xs i ys == take i xs <> ys <> drop (i + 1) xs
+-- source order <-- reverse -> de Bruijn order
+prop_replaceCaseArg_matchesSourceOrderModel :: Property
+prop_replaceCaseArg_matchesSourceOrderModel = property $ do
+  slotCount <- forAll (Gen.int (Range.linear 1 30))
+  caseIndex <- forAll (Gen.int (Range.linear 0 (slotCount - 1)))
+  replacementCount <- forAll (Gen.int (Range.linear 0 8))
+  erasedFlags <- forAll (Gen.list (Range.singleton slotCount) Gen.bool)
+  let sourceSlots =
+        [ if i == caseIndex || not erased
+            then Just ("x" <> show i)
+            else Nothing
+        | (i, erased) <- zip [0 :: Int ..] erasedFlags
+        ]
+      replacements = ["p" <> show i | i <- [0 .. replacementCount - 1]]
+      env = Env (reverse sourceSlots)
+      expectedSourceSlots =
+        take caseIndex sourceSlots
+          <> map Just replacements
+          <> drop (caseIndex + 1) sourceSlots
+      expected = Env (reverse expectedSourceSlots)
+  replaceCaseArg env caseIndex replacements === Right expected
+
+
+-- after replacing argument i with fields,
+-- field j is addressable as Case (i + j)
+prop_replaceCaseArg_makesFieldsAddressableInSourceOrder :: Property
+prop_replaceCaseArg_makesFieldsAddressableInSourceOrder = property $ do
+  beforeCount <- forAll (Gen.int (Range.linear 0 15))
+  afterCount <- forAll (Gen.int (Range.linear 0 15))
+  fieldCount <- forAll (Gen.int (Range.linear 0 8))
+  let before = ["before" <> show i | i <- [0 .. beforeCount - 1]]
+      after = ["after" <> show i | i <- [0 .. afterCount - 1]]
+      fields = ["field" <> show i | i <- [0 .. fieldCount - 1]]
+      sourceNames = before <> ["scrutinee"] <> after
+      env = Env (map Just (reverse sourceNames))
+      caseIndex = beforeCount
+  replaced <- evalEither (replaceCaseArg env caseIndex fields)
+  traverse_
+    (\(offset, field) ->
+      lookupCaseArg replaced (caseIndex + offset) === Right field
+    )
+    (zip [0 :: Int ..] fields)

--- a/test/Compile/TermsProps.hs
+++ b/test/Compile/TermsProps.hs
@@ -2,6 +2,8 @@
 
 module Compile.TermsProps (termsProps) where
 
+import Control.Monad.Trans.State.Strict ( evalStateT )
+import qualified Data.Set as Set
 import Data.Foldable (traverse_)
 import Hedgehog
   ( Group(..)
@@ -9,6 +11,7 @@ import Hedgehog
   , PropertyT
   , annotateShow
   , failure
+  , footnoteShow
   , forAll
   , property
   , (===)
@@ -25,6 +28,7 @@ import Agda.Compiler.Scala.Compile.Terms
   , compileFunctionBody
   , envFromArgs
   , envFromFunction
+  , envNames
   , extendEnv
   , freshPatVars
   , lookupCaseArg
@@ -35,6 +39,7 @@ import Agda.Compiler.Scala.Compile.Terms
 import Agda.Compiler.Scala.Compile (compileBodyTerm)
 import Agda.Compiler.Scala.Compile.Types (CompileError(..))
 import Agda.Compiler.Scala.IR.ScalaExpr (ScalaTerm(..), ScalaPat(..))
+import Agda.Compiler.Scala.Name.NameEnv ( freshNumberedNamesAvoiding, freshNameSupplyFrom )
 
 termsProps :: Group
 termsProps =
@@ -52,7 +57,6 @@ termsProps =
     , ("catch-all branches retain the scrutinized runtime argument", prop_catchallBranch_retainsScrutinee)
     , ("constructor fields replace the scrutinized argument at its source position", prop_replaceCaseArg_preservesSourcePosition)
     , ("constructor fields replace the scrutinized slot in source order", prop_replaceCaseArg_matchesSourceOrderModel)
-    , ("fresh pattern variables are unique and avoid names already in scope", prop_freshPatVars_avoidsNestedShadowing)
     , ("replaceCaseArg makes fields addressable in source order", prop_replaceCaseArg_makesFieldsAddressableInSourceOrder)
     ]
 
@@ -231,18 +235,6 @@ prop_replaceCaseArg_preservesSourcePosition = property $ do
   let env      = Env [ Just "d", Just "c", Just "b", Just "a" ]
       expected = Env [ Just "d", Just "f", Just "e", Just "b", Just "a" ]
   replaceCaseArg env 2 ["e", "f"] === Right expected
-
-prop_freshPatVars_avoidsNestedShadowing :: Property
-prop_freshPatVars_avoidsNestedShadowing = property $ do
-  let env =
-        Env
-          [ Just "p4"
-          , Just "p3"
-          , Just "p2"
-          , Just "p1"
-          , Just "p0"
-          ]
-  freshPatVars env 3 === ["p5", "p6", "p7"]
 
 -- replaceCaseArg xs i ys == take i xs <> ys <> drop (i + 1) xs
 -- source order <-- reverse -> de Bruijn order

--- a/test/Compile/TermsProps.hs
+++ b/test/Compile/TermsProps.hs
@@ -17,10 +17,12 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import Agda.Syntax.Abstract.Name ( QName, mkName_ , qualify_ )
 import Agda.Syntax.Common ( Arg, Hiding(..), NameId(..), defaultArg, setHiding )
+import Agda.TypeChecking.CompiledClause( CompiledClauses'(..), catchall)
 import Agda.Syntax.Internal (Elim' (..), Term (..))
 import Agda.Syntax.TopLevelModuleName.Boot ( noModuleNameHash )
 import Agda.Compiler.Scala.Compile.Terms
   ( Env(..)
+  , compileFunctionBody
   , envFromArgs
   , envFromFunction
   , extendEnv
@@ -30,7 +32,7 @@ import Agda.Compiler.Scala.Compile.Terms
   )
 import Agda.Compiler.Scala.Compile (compileBodyTerm)
 import Agda.Compiler.Scala.Compile.Types (CompileError(..))
-import Agda.Compiler.Scala.IR.ScalaExpr (ScalaTerm(..))
+import Agda.Compiler.Scala.IR.ScalaExpr (ScalaTerm(..), ScalaPat(..))
 
 termsProps :: Group
 termsProps =
@@ -45,6 +47,7 @@ termsProps =
     , ("case arguments use source-order positions including erased binders", prop_lookupCaseArg_usesSourceOrder)
     , ("case branch environment removes the scrutinized argument", prop_removeCaseArg_dropsScrutinee)
     , ("constructor branch binders are added after dropping the case scrutinee", prop_caseBranchEnv_addsPatternBindersAfterDroppingScrutinee)
+    , ("catch-all branches retain the scrutinized runtime argument", prop_catchallBranch_retainsScrutinee)
     ]
 
 mkApply :: Term -> Elim' Term
@@ -188,3 +191,32 @@ visibleArg = defaultArg
 
 hiddenArg :: Term -> Arg Term
 hiddenArg = setHiding Hidden . defaultArg
+
+{-
+Checks:
+- case uses source-order indexing
+- the wildcard RHS still resolves the scrutinized variable
+- hidden type parameters do not disturb either index
+-}
+prop_catchallBranch_retainsScrutinee :: Property
+prop_catchallBranch_retainsScrutinee = property $ do
+    tyCount <- forAll (Gen.int (Range.linear 0 3))
+    argCount <- forAll (Gen.int (Range.linear 1 8))
+    runtimeIndex <- forAll (Gen.int (Range.linear 0 (argCount - 1)))
+
+    let tyParams = [ "A" <> show i | i <- [0 .. tyCount - 1] ]
+        args = [ "x" <> show i | i <- [0 .. argCount - 1] ]
+        caseIndex = tyCount + runtimeIndex
+        deBruijnIndex = argCount - runtimeIndex - 1
+        scrutinizedName = args !! runtimeIndex
+        clauses =
+          Case
+            (defaultArg caseIndex)
+            (catchall (Done [] (Var deBruijnIndex [])))
+        expected =
+          STeMatch
+            (STeVar scrutinizedName)
+            [(SPWild, STeVar scrutinizedName)]
+
+    compileFunctionBody tyParams args (Just clauses) === Right expected
+

--- a/test/Name/NameEnvProps.hs
+++ b/test/Name/NameEnvProps.hs
@@ -24,6 +24,8 @@ import Agda.Compiler.Scala.Name.NameEnv
     , emptyNameEnv
     , sanitizeScalaIdent
     )
+import Agda.Compiler.Scala.Compile.Terms ( freshPatVars, replaceCaseArg )
+import Agda.Compiler.Scala.Compile.Terms ( Env(..) )
 
 nameEnvProps :: Group
 nameEnvProps =
@@ -38,6 +40,8 @@ nameEnvProps =
         , ("fresh local allocation never returns a Scala keyword", prop_allocFreshLocal_unique_nonKeyword)
         , ("fresh local allocation marks every returned name as taken", prop_allocFreshLocal_marksAllocatedNamesTaken)
         , ("first allocation returns the sanitized base name when it is available", prop_allocFreshLocal_firstUsesSanitizedBase)
+        , ("constructor fields replace the scrutinized argument at its source position", prop_replaceCaseArg_preservesSourcePosition)
+        , ("constructor fields replace the scrutinized slot in source order", prop_freshPatVars_avoidsNestedShadowing)
         ]
 
 -- ===== Generators ============================================================
@@ -185,3 +189,21 @@ prop_allocFreshLocal_firstUsesSanitizedBase = property $ do
     rawName <- forAll genRawName
     let (_nameEnv, allocatedName) = allocFreshLocal emptyNameEnv rawName
     allocatedName === sanitizeScalaIdent rawName
+
+prop_replaceCaseArg_preservesSourcePosition :: Property
+prop_replaceCaseArg_preservesSourcePosition = property $ do
+  let env      = Env [ Just "d", Just "c", Just "b", Just "a" ]
+      expected = Env [ Just "d", Just "f", Just "e", Just "b", Just "a" ]
+  replaceCaseArg env 2 ["e", "f"] === Right expected
+
+prop_freshPatVars_avoidsNestedShadowing :: Property
+prop_freshPatVars_avoidsNestedShadowing = property $ do
+  let env =
+        Env
+          [ Just "p4"
+          , Just "p3"
+          , Just "p2"
+          , Just "p1"
+          , Just "p0"
+          ]
+  freshPatVars env 3 === ["p5", "p6", "p7"]

--- a/test/Name/NameEnvProps.hs
+++ b/test/Name/NameEnvProps.hs
@@ -22,8 +22,10 @@ import Agda.Compiler.Scala.Name.NameEnv
     ( NameEnv (..)
     , allocFreshLocal
     , emptyNameEnv
+    , freshNameSupplyFrom
     , freshNumberedNamesAvoiding
     , sanitizeScalaIdent
+    , takeFreshNumberedNames
     )
 
 nameEnvProps :: Group
@@ -40,6 +42,8 @@ nameEnvProps =
         , ("fresh local allocation marks every returned name as taken", prop_allocFreshLocal_marksAllocatedNamesTaken)
         , ("first allocation returns the sanitized base name when it is available", prop_allocFreshLocal_firstUsesSanitizedBase)
         , ("numbered fresh names have the requested count and avoid reserved names", prop_freshNumberedNames_areFresh)
+        , ( "numbered fresh names are never reused across successive allocations", prop_freshNumberedNames_areNeverReused
+          )
         ]
 
 -- ===== Generators ============================================================
@@ -197,3 +201,24 @@ prop_freshNumberedNames_areFresh = property $ do
   length generated === count
   length (nub generated) === count
   assert (all (\name -> not (name `HS.member` taken)) generated)
+
+-- for arbitrary initial names and arbitrary allocation sizes,
+-- all generated names remain globally unique
+prop_freshNumberedNames_areNeverReused :: Property
+prop_freshNumberedNames_areNeverReused =
+  property $ do
+    initiallyTakenCount <- forAll (Gen.int (Range.linear 0 20))
+    outerCount <- forAll (Gen.int (Range.linear 0 20))
+    innerCount <- forAll (Gen.int (Range.linear 0 20))
+    let initiallyTaken = [ "p" <> show i | i <- [0 .. initiallyTakenCount - 1] ]
+        supply0 = freshNameSupplyFrom initiallyTaken
+        (outerNames, supply1) = takeFreshNumberedNames "p" outerCount supply0
+        -- At this point outerNames may no longer occur in the Agda Env.
+        -- The supply must nevertheless keep them permanently reserved.
+        (innerNames, _supply2) = takeFreshNumberedNames "p" innerCount supply1
+        allGenerated = outerNames <> innerNames
+    length outerNames === outerCount
+    length innerNames === innerCount
+    length (nub allGenerated) === length allGenerated
+    assert (all (\name -> name `notElem` initiallyTaken) allGenerated )
+    assert (null (Set.intersection (Set.fromList outerNames) (Set.fromList innerNames) ))

--- a/test/Name/NameEnvProps.hs
+++ b/test/Name/NameEnvProps.hs
@@ -22,10 +22,9 @@ import Agda.Compiler.Scala.Name.NameEnv
     ( NameEnv (..)
     , allocFreshLocal
     , emptyNameEnv
+    , freshNumberedNamesAvoiding
     , sanitizeScalaIdent
     )
-import Agda.Compiler.Scala.Compile.Terms ( freshPatVars, replaceCaseArg )
-import Agda.Compiler.Scala.Compile.Terms ( Env(..) )
 
 nameEnvProps :: Group
 nameEnvProps =
@@ -40,8 +39,7 @@ nameEnvProps =
         , ("fresh local allocation never returns a Scala keyword", prop_allocFreshLocal_unique_nonKeyword)
         , ("fresh local allocation marks every returned name as taken", prop_allocFreshLocal_marksAllocatedNamesTaken)
         , ("first allocation returns the sanitized base name when it is available", prop_allocFreshLocal_firstUsesSanitizedBase)
-        , ("constructor fields replace the scrutinized argument at its source position", prop_replaceCaseArg_preservesSourcePosition)
-        , ("constructor fields replace the scrutinized slot in source order", prop_freshPatVars_avoidsNestedShadowing)
+        , ("numbered fresh names have the requested count and avoid reserved names", prop_freshNumberedNames_areFresh)
         ]
 
 -- ===== Generators ============================================================
@@ -190,20 +188,12 @@ prop_allocFreshLocal_firstUsesSanitizedBase = property $ do
     let (_nameEnv, allocatedName) = allocFreshLocal emptyNameEnv rawName
     allocatedName === sanitizeScalaIdent rawName
 
-prop_replaceCaseArg_preservesSourcePosition :: Property
-prop_replaceCaseArg_preservesSourcePosition = property $ do
-  let env      = Env [ Just "d", Just "c", Just "b", Just "a" ]
-      expected = Env [ Just "d", Just "f", Just "e", Just "b", Just "a" ]
-  replaceCaseArg env 2 ["e", "f"] === Right expected
-
-prop_freshPatVars_avoidsNestedShadowing :: Property
-prop_freshPatVars_avoidsNestedShadowing = property $ do
-  let env =
-        Env
-          [ Just "p4"
-          , Just "p3"
-          , Just "p2"
-          , Just "p1"
-          , Just "p0"
-          ]
-  freshPatVars env 3 === ["p5", "p6", "p7"]
+prop_freshNumberedNames_areFresh :: Property
+prop_freshNumberedNames_areFresh = property $ do
+  count <- forAll (Gen.int (Range.linear 0 50))
+  takenIndices <- forAll (Gen.list (Range.linear 0 80) (Gen.int (Range.linear 0 100)))
+  let taken = HS.fromList [ "p" <> show i | i <- takenIndices ]
+      generated = freshNumberedNamesAvoiding taken "p" count
+  length generated === count
+  length (nub generated) === count
+  assert (all (\name -> not (name `HS.member` taken)) generated)

--- a/test/Name/NameEnvTest.hs
+++ b/test/Name/NameEnvTest.hs
@@ -3,13 +3,15 @@ module Name.NameEnvTest (tests) where
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, testCase)
 
 import Agda.Compiler.Scala.Name.NameEnv
     ( NameEnv (..)
     , allocFreshLocal
     , emptyNameEnv
+    , freshNameSupplyFrom
     , sanitizeScalaIdent
+    , takeFreshNumberedNames
     )
 
 tests :: TestTree
@@ -24,6 +26,7 @@ tests =
         , testCase "allocFreshLocal uses the sanitized base name when it is free" test_allocFreshLocal_first
         , testCase "allocFreshLocal appends numeric suffixes on collisions" test_allocFreshLocal_collision
         , testCase "allocFreshLocal freshens names after keyword sanitization" test_allocFreshLocal_keywordCollision
+        , testCase "numbered fresh names skip candidates already reserved" test_freshNumberedNames_skipsTakenCandidates
         ]
 
 test_emptyNameEnv :: IO ()
@@ -73,3 +76,12 @@ test_allocFreshLocal_keywordCollision = do
     assertBool
         "both allocated names are marked taken"
         (all (`HS.member` neTaken ne2) ["match_", "match__1"])
+
+test_freshNumberedNames_skipsTakenCandidates :: Assertion
+test_freshNumberedNames_skipsTakenCandidates = do
+    let supply0 = freshNameSupplyFrom ["p0", "p2"]
+        (names, _supply1) = takeFreshNumberedNames "p" 3 supply0
+    assertEqual
+        "skips names already reserved"
+        ["p1", "p3", "p4"]
+        names


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added red-black tree insertion for the Agda, Scala 2, and Scala 3 examples, including rebalancing and automatic root-color correction.
  - Improved Scala case compilation to better handle inherited fallbacks and catch-all branches.
- **Bug Fixes**
  - Ensured catch-all branch compilation preserves correct runtime scrutinee selection.
- **Tests**
  - Expanded property tests for catch-all behavior, case-argument replacement correctness, and fresh-name generation; updated red-black tree specs to cover insert/lookup behavior.
- **Chores**
  - Added the `transformers` build dependency for relevant components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->