### PR TITLE
Support covariant types

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -85,8 +85,8 @@ jobs:
 
       - name: Compile example Agda code to Scala 3
         run: |
-          cabal run -- agda2scala --out-dir=scala3/src/main/scala ./examples/adts.agda
-          cabal run -- agda2scala --out-dir=scala3/src/main/scala ./examples/rbt.agda
+          cabal run -- agda2scala --scala-dialect=Scala3 --out-dir=scala3/src/main/scala ./examples/adts.agda
+          cabal run -- agda2scala --scala-dialect=Scala3 --out-dir=scala3/src/main/scala ./examples/rbt.agda
 
       - name: Set up JVM
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5

--- a/README.md
+++ b/README.md
@@ -8,29 +8,83 @@ Currently supported:
   * ✅ simple ADTs
   * ✅ polymorphic ADTs, e.g. `Maybe[A]`, `List[A]`
   * ✅ constructors with arguments
+  * ✅ inferred covariance for generated ADTs where safe, e.g. `RedBlackTree[+V]`
+  * ✅ nullary polymorphic constructors lowered with `Nothing`, e.g. `EmptyRBT extends RedBlackTree[Nothing]`
 * ✅ Product types / records
   * ✅ simple records
   * ✅ records with polymorphic parameters
 * ✅ Simple and polymorphic functions, e.g. `id[A]`
-* ✅ Literals: `Int` / `Nat`, `Bool`, `String` (subset)
+* ✅ Literals
+  * ✅ `Int` / `Nat`
+  * ✅ `Bool`
+  * ✅ `String`
+  * 🚧 broader literal coverage
 * ✅ Function application
   * ✅ normal visible arguments
   * ✅ erased hidden/type-level Agda arguments
+  * ✅ constructor application
+  * ✅ recursive function calls
 * ✅ Pattern matching on constructors
   * ✅ zero-arity constructors
   * ✅ flat constructor patterns with arguments
   * ✅ constructor branch binders
-  * 🚧 nested constructor patterns
-  * 🚧 literal branches / catch-all branches
+  * ✅ nested constructor patterns
+  * ✅ catch-all branches
+  * ✅ inherited catch-all propagation through nested matches
+  * ✅ fresh pattern-variable generation without lexical shadowing
+  * ✅ correct replacement of scrutinized arguments in Agda case environments
+  * ✅ rejection of case splits with no runtime alternatives
+  * 🚧 literal branches
+  * 🚧 projection-pattern cases
+  * 🚧 exhaustive-match simplification and removal of unreachable wildcard branches
 * ✅ Basic conditionals and operators
   * ✅ Agda `if_then_else_` lowered to Scala `if ... then ... else ...`
   * ✅ selected binary operators
   * ✅ natural-number boolean comparison `_ <ᵇ _` lowered to Scala `<`
+  * 🚧 broader operator coverage
+* ✅ Generated Scala 2 and Scala 3
+  * ✅ Scala 2 sealed traits, case classes, and case objects
+  * ✅ Scala 3 enums and enum cases
+  * ✅ nested pattern matches in both dialects
+  * ✅ polymorphic ADTs with variance in both dialects
+  * ✅ generated Red-Black Tree `lookup`
+  * ✅ generated Red-Black Tree `insert` and balancing
+  * ✅ runtime tests for lookup after single and multiple inserts
 * ✅ 🚧 Mapping selected Agda stdlib names to Scala stdlib-like output
   * ✅ `Nat`
   * ✅ `List`
   * ✅ pairs / products
   * 🚧 broader stdlib coverage
+  * 🚧 principled mapping table with types, constructors, functions, and operators
+* 🚧 Variance inference
+  * ✅ positive occurrences
+  * ✅ negative occurrences through function inputs
+  * ✅ mixed occurrences lowered invariantly
+  * ✅ conservative treatment of unknown type constructors
+  * ✅ algebraic occurrence accumulation using a `Monoid`
+  * 🚧 variance propagation through known Scala and Agda type constructors
+  * 🚧 contravariant parameters
+  * 🚧 variance validation for records and other generated declarations
+* 🚧 Compiler robustness
+  * ✅ explicit errors for unsupported case-tree shapes
+  * ✅ property tests for de Bruijn environments and source-order case indices
+  * ✅ property tests for constructor-field replacement
+  * ✅ property tests for fresh-name supply
+  * ✅ algebraic-law tests for variance occurrence accumulation
+  * 🚧 structured diagnostics with source definition names and context
+  * 🚧 golden tests for generated Scala files
+  * 🚧 compile generated Scala automatically as part of Haskell integration tests
+* 🚧 Larger language features
+  * 🚧 local `let` bindings
+  * 🚧 lambda expressions
+  * 🚧 higher-order functions
+  * 🚧 mutually recursive functions
+  * 🚧 recursive and mutually recursive datatypes
+  * 🚧 dependent pairs and indexed datatypes
+  * 🚧 type classes / Agda instance arguments
+  * 🚧 modules, imports, and namespace mapping
+  * 🚧 termination and totality assumptions in generated Scala
+
 
 Roadmap is captured in milestones:
 * support polymorphic ADTs: List, Red Black Tree, ZIO: https://github.com/dancewithheart/agda2scala/issues/17

--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -132,6 +132,7 @@ test-suite agda2scala-props
     Compile.TermsProps
     Compile.TypesProps
     Lower.IRToScalaProps
+    Lower.VarianceProps
     Name.NameEnvProps
     Name.NamePolicyProps
     Render.PrintProps

--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -45,6 +45,7 @@ library
     Agda.Compiler.Scala.IR.ScalaIR
     Agda.Compiler.Scala.Lower.AgdaToIR
     Agda.Compiler.Scala.Lower.IRToScala
+    Agda.Compiler.Scala.Lower.Variance
     Agda.Compiler.Scala.Render.Common
     Agda.Compiler.Scala.Render.PrintScala3
     Agda.Compiler.Scala.Render.PrintScala2
@@ -102,6 +103,7 @@ test-suite agda2scala-test
   main-is:          Tests.hs
   other-modules:
     Compile.TypesTest
+    Lower.VarianceTest
     Name.NameEnvTest
     Name.NamePolicyTest
     Render.CommonTest

--- a/scala2/src/main/scala/examples/adts.scala
+++ b/scala2/src/main/scala/examples/adts.scala
@@ -36,16 +36,16 @@ def withEscapes(): String = "line1\nline2\t\"quote\"\\backslash"
 
 def id[A](x1: A): A = x1
 
-sealed trait Maybe[A]
+sealed trait Maybe[+A]
 object Maybe {
-  final case class Just[A](x0: A) extends Maybe[A]
+  final case class Just[+A](x0: A) extends Maybe[A]
   case object None extends Maybe[Nothing]
 }
 
-sealed trait List[X]
+sealed trait List[+X]
 object List {
   case object Nil extends List[Nothing]
-  final case class Cons[X](x0: X, x1: List[X]) extends List[X]
+  final case class Cons[+X](x0: X, x1: List[X]) extends List[X]
 }
 
 def not(x0: Answer): Answer = x0 match {
@@ -58,7 +58,7 @@ def not(x0: Answer): Answer = x0 match {
 def unColor(x0: Color): Rgb = x0 match {
   case Color.Light(p0) =>
     p0
-  case Color.Dark(p0) =>
-    p0
+  case Color.Dark(p1) =>
+    p1
 }
 }

--- a/scala2/src/main/scala/examples/rbt.scala
+++ b/scala2/src/main/scala/examples/rbt.scala
@@ -9,10 +9,10 @@ object Color {
   case object Black extends Color
 }
 
-sealed trait RedBlackTree[V]
+sealed trait RedBlackTree[+V]
 object RedBlackTree {
   case object EmptyRBT extends RedBlackTree[Nothing]
-  final case class RBT[V](x0: Color, x1: RedBlackTree[V], x2: Long, x3: V, x4: RedBlackTree[V]) extends RedBlackTree[V]
+  final case class RBT[+V](x0: Color, x1: RedBlackTree[V], x2: Long, x3: V, x4: RedBlackTree[V]) extends RedBlackTree[V]
 }
 
 def lookup[V](x1: V, x2: Long, x3: RedBlackTree[V]): V = x3 match {

--- a/scala2/src/test/scala/examples/RedBlackTreeSpec.scala
+++ b/scala2/src/test/scala/examples/RedBlackTreeSpec.scala
@@ -6,18 +6,13 @@ import zio.test.assertTrue
 import examples.rbt.RedBlackTree
 import examples.rbt.Color
 import examples.rbt.RedBlackTree.EmptyRBT
-import examples.rbt.lookup
+import examples.rbt.{insert, lookup}
 
 object RedBlackTreeSpec extends JUnitRunnableSpec {
 
-  // temporary until generated RedBlackTree is covariant
-  // https://github.com/dancewithheart/agda2scala/issues/26
-  private def emptyRBT[V]: RedBlackTree[V] =
-    EmptyRBT.asInstanceOf[RedBlackTree[V]]
-
   def spec = suite("RedBlackTree")(
     test("lookup on empty rbt returns default value") {
-      val rbt = emptyRBT[String]
+      val rbt = EmptyRBT
       val defaultVal = "missing"
       val key = 42L
       assertTrue(defaultVal == lookup(defaultVal, key, rbt))
@@ -27,22 +22,22 @@ object RedBlackTreeSpec extends JUnitRunnableSpec {
       val rbt =
         RedBlackTree.RBT[String](
           Color.Black,
-          emptyRBT[String],
+          EmptyRBT,
           42L,
           "found",
-          emptyRBT[String]
+          EmptyRBT
         )
 
       assertTrue(lookup("missing", 42L, rbt) == "found")
     },
 
     test("lookup after single insert returns inserted value") {
-      val t1 = insert(42L, "found", emptyRBT[String])
+      val t1 = insert(42L, "found", EmptyRBT)
       assertTrue(lookup("missing", 42L, t1) == "found")
     },
 
     test("lookup after several inserts returns matching values") {
-      val t0 = emptyRBT[String]
+      val t0 = EmptyRBT
       val t1 = insert(10L, "a", t0)
       val t2 = insert(5L, "b", t1)
       val t3 = insert(20L, "c", t2)

--- a/scala3/src/main/scala/examples/adts.scala
+++ b/scala3/src/main/scala/examples/adts.scala
@@ -28,13 +28,13 @@ object adts:
 
   def id[A](x1: A): A = x1
 
-  enum Maybe[A]:
-    case Just[A](x0: A) extends Maybe[A]
+  enum Maybe[+A]:
+    case Just(x0: A) extends Maybe[A]
     case None extends Maybe[Nothing]
 
-  enum List[X]:
+  enum List[+X]:
     case Nil extends List[Nothing]
-    case Cons[X](x0: X, x1: List[X]) extends List[X]
+    case Cons(x0: X, x1: List[X]) extends List[X]
 
   def not(x0: Answer): Answer = x0 match
     case Answer.Yes =>
@@ -45,5 +45,5 @@ object adts:
   def unColor(x0: Color): Rgb = x0 match
     case Color.Light(p0) =>
       p0
-    case Color.Dark(p0) =>
-      p0
+    case Color.Dark(p1) =>
+      p1

--- a/scala3/src/main/scala/examples/rbt.scala
+++ b/scala3/src/main/scala/examples/rbt.scala
@@ -5,9 +5,9 @@ object rbt:
     case Red
     case Black
 
-  enum RedBlackTree[V]:
+  enum RedBlackTree[+V]:
     case EmptyRBT extends RedBlackTree[Nothing]
-    case RBT[V](x0: Color, x1: RedBlackTree[V], x2: Long, x3: V, x4: RedBlackTree[V]) extends RedBlackTree[V]
+    case RBT(x0: Color, x1: RedBlackTree[V], x2: Long, x3: V, x4: RedBlackTree[V]) extends RedBlackTree[V]
 
   def lookup[V](x1: V, x2: Long, x3: RedBlackTree[V]): V = x3 match
     case RedBlackTree.EmptyRBT =>

--- a/scala3/src/test/scala/examples/RedBlackTreeSpec.scala
+++ b/scala3/src/test/scala/examples/RedBlackTreeSpec.scala
@@ -10,14 +10,9 @@ import examples.rbt.{insert, lookup}
 
 object RedBlackTreeSpec extends JUnitRunnableSpec:
 
-  // temporary until generated RedBlackTree is covariant
-  // https://github.com/dancewithheart/agda2scala/issues/26
-  private def emptyRBT[V]: RedBlackTree[V] =
-    EmptyRBT.asInstanceOf[RedBlackTree[V]]
-
   def spec = suite("Test Rgb")(
     test("lookup on empty rbt returns default value") {
-      val rbt = emptyRBT[String]
+      val rbt = EmptyRBT
       val defaultVal = "foo"
       val key = 42L
       assertTrue(defaultVal == lookup(defaultVal, key, rbt))
@@ -27,21 +22,21 @@ object RedBlackTreeSpec extends JUnitRunnableSpec:
       val rbt =
         RedBlackTree.RBT[String](
           Color.Black,
-          emptyRBT[String],
+          EmptyRBT,
           42L,
           "found",
-          emptyRBT[String]
+          EmptyRBT
         )
       assertTrue(lookup("default", 42L, rbt) == "found")
     },
 
     test("lookup after single insert returns inserted value") {
-      val t1 = insert(42L, "found", emptyRBT[String])
+      val t1 = insert(42L, "found", EmptyRBT)
       assertTrue(lookup("missing", 42L, t1) == "found")
     },
 
     test("lookup after several inserts returns matching values") {
-      val t0 = emptyRBT[String]
+      val t0 = EmptyRBT
       val t1 = insert(10L, "a", t0)
       val t2 = insert(5L, "b", t1)
       val t3 = insert(20L, "c", t2)

--- a/src/Agda/Compiler/Scala/Compile/Terms.hs
+++ b/src/Agda/Compiler/Scala/Compile/Terms.hs
@@ -195,9 +195,10 @@ compileCompiledClauses inheritedFallback env clauses =
             case caseFallback of
               Nothing -> []
               Just fallback -> [(SPWild, fallback)]
-      pure (STeMatch scrutinee (constructorAlternatives <> fallbackAlternatives))
---    _ -> liftCompile (Left UnsupportedCompiledClauses)
-
+          alternatives = constructorAlternatives <> fallbackAlternatives
+      case alternatives of
+        [] -> liftCompile (Left (UnsupportedCaseShape HasNoRuntimeAlternatives))
+        _  -> pure (STeMatch scrutinee alternatives)
 
 compileConstructorBranch
   :: Int

--- a/src/Agda/Compiler/Scala/Compile/Types.hs
+++ b/src/Agda/Compiler/Scala/Compile/Types.hs
@@ -66,6 +66,7 @@ data CaseUnsupported
   = HasLiteralBranches
   | HasFallThrough
   | HasProjectionPatterns
+  | HasNoRuntimeAlternatives
   deriving (Eq, Show)
 
 -- ===== Type variable environment ============================================

--- a/src/Agda/Compiler/Scala/IR/ScalaExpr.hs
+++ b/src/Agda/Compiler/Scala/IR/ScalaExpr.hs
@@ -1,14 +1,17 @@
-module Agda.Compiler.Scala.IR.ScalaExpr (
-    ScalaName,
-    ScalaType (..),
-    ScalaExpr (..),
-    SeVar (..),
-    ScalaPat (..),
-    ScalaTerm (..),
-    ScalaTypeScheme (..),
-    ScalaCtor (..),
-    scalaTypeScheme,
-    unHandled,
+module Agda.Compiler.Scala.IR.ScalaExpr
+  ( ScalaName
+  , ScalaType (..)
+  , ScalaExpr (..)
+  , SeVar (..)
+  , ScalaPat (..)
+  , ScalaTerm (..)
+  , ScalaTypeScheme (..)
+  , ScalaCtor (..)
+  , ScalaTyParam(..)
+  , ScalaVariance(..)
+  , scalaTypeScheme
+  , tyParamNames
+  , unHandled
 ) where
 
 type ScalaName = String
@@ -62,7 +65,7 @@ data ScalaCtor = ScalaCtor
 
 data ScalaExpr
     = SePackage [ScalaName] [ScalaExpr]
-    | SeSum ScalaName [ScalaName] [ScalaCtor] -- name, type params, ctors
+    | SeSum ScalaName [ScalaTyParam] [ScalaCtor] -- name, type params, ctors
     | SeProd ScalaName [ScalaName] [SeVar] -- name, type params, fields
     | SeFun ScalaName [SeVar] ScalaTypeScheme ScalaTerm
     | SeUnhandled ScalaName String
@@ -71,3 +74,17 @@ data ScalaExpr
 unHandled :: ScalaExpr -> Bool
 unHandled (SeUnhandled _ _) = True
 unHandled _ = False
+
+data ScalaVariance
+  = Invariant
+  | Covariant
+  deriving (Eq, Show)
+
+data ScalaTyParam = ScalaTyParam
+  { stpName :: ScalaName
+  , stpVariance :: ScalaVariance
+  }
+  deriving (Eq, Show)
+
+tyParamNames :: [ScalaTyParam] -> [ScalaName]
+tyParamNames = map stpName

--- a/src/Agda/Compiler/Scala/Lower/IRToScala.hs
+++ b/src/Agda/Compiler/Scala/Lower/IRToScala.hs
@@ -23,13 +23,14 @@ import Agda.Compiler.Scala.IR.ScalaExpr
   , ScalaTerm(..)
   , SeVar(..)
   )
+import Agda.Compiler.Scala.Lower.Variance ( inferDataTyParams )
 
 toScalaExpr :: NamePolicy -> AgdaDecl -> ScalaExpr
 toScalaExpr policy decl = case decl of
   DData d ->
     SeSum
       (typeName policy (adName d))
-      (adTyParams d)
+      (inferDataTyParams (adName d) (adTyParams d) (adCtors d))
       (map (lowerCtor policy) (adCtors d))
   DRecord r ->
     SeProd

--- a/src/Agda/Compiler/Scala/Lower/Variance.hs
+++ b/src/Agda/Compiler/Scala/Lower/Variance.hs
@@ -1,9 +1,8 @@
 module Agda.Compiler.Scala.Lower.Variance
   ( inferDataTyParams
   , inferParamVariance
+  , Occurrence
   ) where
-
-import Data.List (foldl')
 
 import Agda.Compiler.Scala.IR.ScalaExpr
   ( ScalaCtor(..)
@@ -23,7 +22,17 @@ data Occurrence
   | PositiveOnly
   | NegativeOnly
   | Mixed
-  deriving (Eq, Show)
+  deriving (Eq, Show, Enum, Bounded)
+
+instance Semigroup Occurrence where
+  Absent <> other = other
+  other <> Absent = other
+  PositiveOnly <> PositiveOnly = PositiveOnly
+  NegativeOnly <> NegativeOnly = NegativeOnly
+  _ <> _ = Mixed
+
+instance Monoid Occurrence where
+  mempty = Absent
 
 inferDataTyParams
   :: ScalaName
@@ -47,11 +56,8 @@ inferParamVariance dataName param ctors =
     NegativeOnly -> Invariant
     Mixed        -> Invariant
   where
-    evidence =
-      foldl'
-        combineOccurrence
-        Absent
-        [ occurrences dataName param Positive argTy | ctor <- ctors, argTy <- scArgs ctor ]
+    evidence = foldMap occurrencesInCtor ctors
+    occurrencesInCtor ctor = foldMap (occurrences dataName param Positive) (scArgs ctor)
 
 occurrences
   :: ScalaName
@@ -65,15 +71,12 @@ occurrences dataName param polarity scalaType =
     STyVar name
       | name == param -> occurrenceAt polarity
       | otherwise     -> Absent
-    STyFun input output -> combineOccurrence
-      (occurrences dataName param (flipPolarity polarity) input)
-      (occurrences dataName param polarity output)
+    STyFun input output ->
+      occurrences dataName param (flipPolarity polarity) input
+      <> occurrences dataName param polarity output
     STyApp typeName args
       | typeName == dataName ->
-          foldl'
-            combineOccurrence
-            Absent
-            (map (occurrences dataName param polarity) args)
+          foldMap (occurrences dataName param polarity) args
       | any (mentions param) args -> Mixed
       | otherwise -> Absent
 
@@ -96,12 +99,3 @@ flipPolarity polarity =
   case polarity of
     Positive -> Negative
     Negative -> Positive
-
-combineOccurrence :: Occurrence -> Occurrence -> Occurrence
-combineOccurrence left right =
-  case (left, right) of
-    (Absent, other) -> other
-    (other, Absent) -> other
-    (PositiveOnly, PositiveOnly) -> PositiveOnly
-    (NegativeOnly, NegativeOnly) -> NegativeOnly
-    _ -> Mixed

--- a/src/Agda/Compiler/Scala/Lower/Variance.hs
+++ b/src/Agda/Compiler/Scala/Lower/Variance.hs
@@ -1,0 +1,107 @@
+module Agda.Compiler.Scala.Lower.Variance
+  ( inferDataTyParams
+  , inferParamVariance
+  ) where
+
+import Data.List (foldl')
+
+import Agda.Compiler.Scala.IR.ScalaExpr
+  ( ScalaCtor(..)
+  , ScalaName
+  , ScalaTyParam(..)
+  , ScalaType(..)
+  , ScalaVariance(..)
+  )
+
+data Polarity
+  = Positive
+  | Negative
+  deriving (Eq, Show)
+
+data Occurrence
+  = Absent
+  | PositiveOnly
+  | NegativeOnly
+  | Mixed
+  deriving (Eq, Show)
+
+inferDataTyParams
+  :: ScalaName
+  -> [ScalaName]
+  -> [ScalaCtor]
+  -> [ScalaTyParam]
+inferDataTyParams dataName params ctors =
+  [ ScalaTyParam param (inferParamVariance dataName param ctors)
+  | param <- params
+  ]
+
+inferParamVariance
+  :: ScalaName
+  -> ScalaName
+  -> [ScalaCtor]
+  -> ScalaVariance
+inferParamVariance dataName param ctors =
+  case evidence of
+    Absent       -> Covariant
+    PositiveOnly -> Covariant
+    NegativeOnly -> Invariant
+    Mixed        -> Invariant
+  where
+    evidence =
+      foldl'
+        combineOccurrence
+        Absent
+        [ occurrences dataName param Positive argTy | ctor <- ctors, argTy <- scArgs ctor ]
+
+occurrences
+  :: ScalaName
+  -> ScalaName
+  -> Polarity
+  -> ScalaType
+  -> Occurrence
+occurrences dataName param polarity scalaType =
+  case scalaType of
+    STyName _ -> Absent
+    STyVar name
+      | name == param -> occurrenceAt polarity
+      | otherwise     -> Absent
+    STyFun input output -> combineOccurrence
+      (occurrences dataName param (flipPolarity polarity) input)
+      (occurrences dataName param polarity output)
+    STyApp typeName args
+      | typeName == dataName ->
+          foldl'
+            combineOccurrence
+            Absent
+            (map (occurrences dataName param polarity) args)
+      | any (mentions param) args -> Mixed
+      | otherwise -> Absent
+
+mentions :: ScalaName -> ScalaType -> Bool
+mentions param scalaType =
+  case scalaType of
+    STyName _ -> False
+    STyVar name -> name == param
+    STyFun input output -> mentions param input || mentions param output
+    STyApp _ args -> any (mentions param) args
+
+occurrenceAt :: Polarity -> Occurrence
+occurrenceAt polarity =
+  case polarity of
+    Positive -> PositiveOnly
+    Negative -> NegativeOnly
+
+flipPolarity :: Polarity -> Polarity
+flipPolarity polarity =
+  case polarity of
+    Positive -> Negative
+    Negative -> Positive
+
+combineOccurrence :: Occurrence -> Occurrence -> Occurrence
+combineOccurrence left right =
+  case (left, right) of
+    (Absent, other) -> other
+    (other, Absent) -> other
+    (PositiveOnly, PositiveOnly) -> PositiveOnly
+    (NegativeOnly, NegativeOnly) -> NegativeOnly
+    _ -> Mixed

--- a/src/Agda/Compiler/Scala/Render/Common.hs
+++ b/src/Agda/Compiler/Scala/Render/Common.hs
@@ -9,6 +9,7 @@ module Agda.Compiler.Scala.Render.Common
   , printPat
   , printType
   , printTyParams
+  , printVariantTyParams
   , sp
   , strip
   ) where
@@ -19,6 +20,8 @@ import Agda.Compiler.Scala.IR.ScalaExpr
   ( ScalaName
   , ScalaPat(..)
   , ScalaType (..)
+  , ScalaVariance (..)
+  , ScalaTyParam (..)
   )
 
 -- Escaping for Scala string literal content (no surrounding quotes).
@@ -88,3 +91,17 @@ combineLines = intercalate nl . filter (not . null)
 
 asBottom :: [ScalaName] -> [ScalaName]
 asBottom ps = replicate (length ps) "Nothing"
+
+printVariantTyParams :: [ScalaTyParam] -> String
+printVariantTyParams [] = ""
+printVariantTyParams params =
+  "[" <> intercalate ", " (map printVariantTyParam params) <> "]"
+
+printVariantTyParam :: ScalaTyParam -> String
+printVariantTyParam (ScalaTyParam name variance) = variancePrefix variance <> name
+
+variancePrefix :: ScalaVariance -> String
+variancePrefix variance =
+  case variance of
+    Invariant -> ""
+    Covariant -> "+"

--- a/src/Agda/Compiler/Scala/Render/PrintScala2.hs
+++ b/src/Agda/Compiler/Scala/Render/PrintScala2.hs
@@ -21,18 +21,21 @@ import Agda.Compiler.Scala.Render.Common
   , printPat
   , printType
   , printTyParams
+  , printVariantTyParams
   , sp
   )
-import Agda.Compiler.Scala.IR.ScalaExpr (
-    ScalaCtor (..),
-    ScalaExpr (..),
-    ScalaName,
-    ScalaPat(..),
-    ScalaTerm (..),
-    ScalaType (..),
-    ScalaTypeScheme (..),
-    SeVar (..),
- )
+import Agda.Compiler.Scala.IR.ScalaExpr
+  ( ScalaCtor (..)
+  , ScalaExpr (..)
+  , ScalaName
+  , ScalaPat(..)
+  , ScalaTerm (..)
+  , ScalaType (..)
+  , ScalaTyParam
+  , ScalaTypeScheme (..)
+  , SeVar (..)
+  , tyParamNames
+  )
 
 printScala2 :: ScalaExpr -> String
 printScala2 def = case def of
@@ -77,29 +80,31 @@ printScala2 def = case def of
 
 -- ===== Sum types ============================================================
 
-printSum :: ScalaName -> [ScalaName] -> [ScalaCtor] -> String
+printSum :: ScalaName -> [ScalaTyParam] -> [ScalaCtor] -> String
 printSum name tyParams ctors =
-    printSealedTrait name
-        <> printTyParams tyParams
-        <> nl
-        <> printCompanionObject name (map (printCtor name tyParams) ctors)
+  printSealedTrait name
+    <> printVariantTyParams tyParams
+    <> nl
+    <> printCompanionObject name (map (printCtor name tyParams) ctors)
 
-printCtor :: ScalaName -> [ScalaName] -> ScalaCtor -> String
-printCtor superName tyParams (ScalaCtor cName []) =
-    printCaseObject (superName <> printTyParams (asBottom tyParams)) cName
-printCtor superName tyParams (ScalaCtor name argTys) =
-    "final case class"
-        <> sp
-        <> name
-        <> printTyParams tyParams
-        <> "("
-        <> intercalate ", " (zipWith ctorParam [0 :: Int ..] argTys)
-        <> ")"
-        <> sp
-        <> "extends"
-        <> sp
-        <> superName
-        <> printTyParams tyParams
+printCtor :: ScalaName -> [ScalaTyParam] -> ScalaCtor -> String
+printCtor superName tyParams (ScalaCtor ctorName []) =
+  printCaseObject
+    (superName <> printTyParams (asBottom (tyParamNames tyParams)))
+    ctorName
+printCtor superName tyParams (ScalaCtor ctorName argTys) =
+  "final case class"
+    <> sp
+    <> ctorName
+    <> printVariantTyParams tyParams
+    <> "("
+    <> intercalate ", " (zipWith ctorParam [0 :: Int ..] argTys)
+    <> ")"
+    <> sp
+    <> "extends"
+    <> sp
+    <> superName
+    <> printTyParams (tyParamNames tyParams)
 
 ctorParam :: Int -> ScalaType -> String
 ctorParam i ty = "x" <> show i <> ":" <> sp <> printType ty

--- a/src/Agda/Compiler/Scala/Render/PrintScala3.hs
+++ b/src/Agda/Compiler/Scala/Render/PrintScala3.hs
@@ -14,18 +14,21 @@ import Agda.Compiler.Scala.Render.Common
   , printPat
   , printType
   , printTyParams
+  , printVariantTyParams
   , strip
   , sp
   )
-import Agda.Compiler.Scala.IR.ScalaExpr (
-    ScalaCtor (..),
-    ScalaExpr (..),
-    ScalaName,
-    ScalaPat(..),
-    ScalaTerm (..),
-    ScalaType (..),
-    ScalaTypeScheme (..),
-    SeVar (..),
+import Agda.Compiler.Scala.IR.ScalaExpr
+  ( ScalaCtor (..)
+  , ScalaExpr (..)
+  , ScalaName
+  , ScalaPat(..)
+  , ScalaTerm (..)
+  , ScalaType (..)
+  , ScalaTyParam (..)
+  , ScalaTypeScheme (..)
+  , SeVar (..)
+  , tyParamNames
  )
 import Data.List (intercalate)
 
@@ -65,27 +68,26 @@ printScala3 def = case def of
 
 -- ===== Sum types ============================================================
 
-printSum :: ScalaName -> [ScalaName] -> [ScalaCtor] -> String
+printSum :: ScalaName -> [ScalaTyParam] -> [ScalaCtor] -> String
 printSum name tyParams ctors =
-    printEnum name
-        <> printTyParams tyParams
-        <> bracketWithIndent (map (printEnumCtor name tyParams) ctors) 2
+  printEnum name
+    <> printVariantTyParams tyParams
+    <> bracketWithIndent (map (printEnumCtor name tyParams) ctors) 2
 
-printEnumCtor :: ScalaName -> [ScalaName] -> ScalaCtor -> String
-printEnumCtor name tyParams (ScalaCtor cName []) =
-    "case"
-        <> exprSeparator
-        <> cName
-        <> printExtends name (asBottom tyParams)
-printEnumCtor name tyParams (ScalaCtor cName argTys) =
-    "case"
-        <> exprSeparator
-        <> cName
-        <> printTyParams tyParams
-        <> "("
-        <> intercalate ", " (zipWith ctorParam [0 :: Int ..] argTys)
-        <> ")"
-        <> printExtends name tyParams
+printEnumCtor :: ScalaName -> [ScalaTyParam] -> ScalaCtor -> String
+printEnumCtor name tyParams (ScalaCtor ctorName []) =
+  "case"
+    <> sp
+    <> ctorName
+    <> printExtends name (asBottom (tyParamNames tyParams))
+printEnumCtor name tyParams (ScalaCtor ctorName argTys) =
+  "case"
+    <> sp
+    <> ctorName
+    <> "("
+    <> intercalate ", " (zipWith ctorParam [0 :: Int ..] argTys)
+    <> ")"
+    <> printExtends name (tyParamNames tyParams)
 
 printExtends :: ScalaName -> [ScalaName] -> String
 printExtends _ [] = ""

--- a/test/Compile/TermsProps.hs
+++ b/test/Compile/TermsProps.hs
@@ -2,8 +2,6 @@
 
 module Compile.TermsProps (termsProps) where
 
-import Control.Monad.Trans.State.Strict ( evalStateT )
-import qualified Data.Set as Set
 import Data.Foldable (traverse_)
 import Hedgehog
   ( Group(..)
@@ -11,7 +9,6 @@ import Hedgehog
   , PropertyT
   , annotateShow
   , failure
-  , footnoteShow
   , forAll
   , property
   , (===)
@@ -30,7 +27,6 @@ import Agda.Compiler.Scala.Compile.Terms
   , envFromFunction
   , envNames
   , extendEnv
-  , freshPatVars
   , lookupCaseArg
   , lookupVar
   , removeCaseArg
@@ -39,7 +35,6 @@ import Agda.Compiler.Scala.Compile.Terms
 import Agda.Compiler.Scala.Compile (compileBodyTerm)
 import Agda.Compiler.Scala.Compile.Types (CompileError(..))
 import Agda.Compiler.Scala.IR.ScalaExpr (ScalaTerm(..), ScalaPat(..))
-import Agda.Compiler.Scala.Name.NameEnv ( freshNumberedNamesAvoiding, freshNameSupplyFrom )
 
 termsProps :: Group
 termsProps =

--- a/test/Compile/TermsProps.hs
+++ b/test/Compile/TermsProps.hs
@@ -3,6 +3,7 @@
 module Compile.TermsProps (termsProps) where
 
 import Data.Foldable (traverse_)
+import qualified Data.Map as Map
 import Hedgehog
   ( Group(..)
   , Property
@@ -17,7 +18,12 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import Agda.Syntax.Abstract.Name ( QName, mkName_ , qualify_ )
 import Agda.Syntax.Common ( Arg, Hiding(..), NameId(..), defaultArg, setHiding )
-import Agda.TypeChecking.CompiledClause( CompiledClauses'(..), catchall)
+import Agda.TypeChecking.CompiledClause
+  ( Case(..)
+  , CompiledClauses
+  , CompiledClauses'(..)
+  , catchall
+  )
 import Agda.Syntax.Internal (Elim' (..), Term (..))
 import Agda.Syntax.TopLevelModuleName.Boot ( noModuleNameHash )
 import Agda.Compiler.Scala.Compile.Terms
@@ -25,7 +31,6 @@ import Agda.Compiler.Scala.Compile.Terms
   , compileFunctionBody
   , envFromArgs
   , envFromFunction
-  , envNames
   , extendEnv
   , lookupCaseArg
   , lookupVar
@@ -33,7 +38,7 @@ import Agda.Compiler.Scala.Compile.Terms
   , replaceCaseArg
   )
 import Agda.Compiler.Scala.Compile (compileBodyTerm)
-import Agda.Compiler.Scala.Compile.Types (CompileError(..))
+import Agda.Compiler.Scala.Compile.Types (CompileError(..), CaseUnsupported(..) )
 import Agda.Compiler.Scala.IR.ScalaExpr (ScalaTerm(..), ScalaPat(..))
 
 termsProps :: Group
@@ -53,6 +58,7 @@ termsProps =
     , ("constructor fields replace the scrutinized argument at its source position", prop_replaceCaseArg_preservesSourcePosition)
     , ("constructor fields replace the scrutinized slot in source order", prop_replaceCaseArg_matchesSourceOrderModel)
     , ("replaceCaseArg makes fields addressable in source order", prop_replaceCaseArg_makesFieldsAddressableInSourceOrder)
+    , ( "case splits with no runtime alternatives are rejected", prop_caseSplitWithNoAlternatives_isRejected)
     ]
 
 mkApply :: Term -> Elim' Term
@@ -274,3 +280,21 @@ prop_replaceCaseArg_makesFieldsAddressableInSourceOrder = property $ do
       lookupCaseArg replaced (caseIndex + offset) === Right field
     )
     (zip [0 :: Int ..] fields)
+
+emptyCaseBranches :: Case CompiledClauses
+emptyCaseBranches =
+  Branches
+    { projPatterns = False
+    , conBranches = Map.empty
+    , etaBranch = Nothing
+    , litBranches = Map.empty
+    , catchallBranch = Nothing
+    , fallThrough = Nothing
+    , lazyMatch = False
+    }
+
+prop_caseSplitWithNoAlternatives_isRejected :: Property
+prop_caseSplitWithNoAlternatives_isRejected = property $ do
+  let clauses = Case (defaultArg 0) emptyCaseBranches
+  compileFunctionBody [] ["x0"] (Just clauses)
+    === Left (UnsupportedCaseShape HasNoRuntimeAlternatives)

--- a/test/Lower/VarianceProps.hs
+++ b/test/Lower/VarianceProps.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Lower.VarianceProps (varianceProps) where
+
+import Data.Foldable (traverse_)
+import Hedgehog
+  ( Group(..)
+  , Property
+  , property
+  , (===)
+  )
+import Agda.Compiler.Scala.Lower.Variance (Occurrence)
+
+varianceProps :: Group
+varianceProps =
+  Group "Terms / Env / application"
+    [ ("occurrence evidence forms a monoid", prop_occurrence_isMonoid)
+    ]
+
+{-# ANN prop_occurrence_isMonoid ("HLint: ignore Monoid law, left identity" :: String) #-}
+{-# ANN prop_occurrence_isMonoid ("HLint: ignore Monoid law, right identity" :: String) #-}
+prop_occurrence_isMonoid :: Property
+prop_occurrence_isMonoid = property $ do
+  traverse_
+    (\a -> do
+      mempty <> a === a
+      a <> mempty === a
+    )
+    allOccurrences
+  traverse_
+    (\(a, b, c) -> (a <> b) <> c === a <> (b <> c) )
+    [ (a, b, c) | a <- allOccurrences, b <- allOccurrences , c <- allOccurrences ]
+
+allOccurrences :: [Occurrence]
+allOccurrences = [minBound .. maxBound]

--- a/test/Lower/VarianceTest.hs
+++ b/test/Lower/VarianceTest.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Lower.VarianceTest (tests) where
+
+import Test.Tasty ( TestTree, testGroup )
+import Test.Tasty.HUnit ( Assertion, assertEqual, testCase )
+
+import Agda.Compiler.Scala.IR.ScalaExpr
+  ( ScalaType (..)
+  , ScalaTyParam (..)
+  , ScalaVariance(..)
+  , ScalaCtor (..)
+  )
+import Agda.Compiler.Scala.Lower.Variance ( inferDataTyParams )
+
+tests :: TestTree
+tests =
+    testGroup
+        "Lower.Variance"
+        [ testCase "RBT is covariant" test_rbtParameterIsCovariant
+        , testCase "Function input prevents covariance" test_negativeOccurrenceIsInvariant
+        , testCase "Positive and negative is invariant" test_mixedOccurrenceIsInvariant
+        , testCase "Unknown wrappers remain conservative" test_unknownTypeConstructorIsInvariant
+        ]
+
+test_rbtParameterIsCovariant :: Assertion
+test_rbtParameterIsCovariant =
+  assertEqual
+    "RBT value parameter occurs only covariantly"
+    [ScalaTyParam "V" Covariant]
+    (inferDataTyParams "RedBlackTree" ["V"] ctors)
+  where
+    v = STyVar "V"
+    treeV = STyApp "RedBlackTree" [v]
+
+    ctors =
+      [ ScalaCtor "EmptyRBT" []
+      , ScalaCtor
+          "RBT"
+          [ STyName "Color"
+          , treeV
+          , STyName "Long"
+          , v
+          , treeV
+          ]
+      ]
+
+test_negativeOccurrenceIsInvariant :: Assertion
+test_negativeOccurrenceIsInvariant =
+  assertEqual
+    "function input is a negative occurrence"
+    [ScalaTyParam "A" Invariant]
+    ( inferDataTyParams
+        "Consumer"
+        ["A"]
+        [ ScalaCtor
+            "Consumer"
+            [STyFun (STyVar "A") (STyName "Long")]
+        ]
+    )
+
+test_mixedOccurrenceIsInvariant :: Assertion
+test_mixedOccurrenceIsInvariant =
+  assertEqual
+    "mixed occurrences require invariance"
+    [ScalaTyParam "A" Invariant]
+    ( inferDataTyParams
+        "Endomorphism"
+        ["A"]
+        [ScalaCtor "Endomorphism" [STyFun (STyVar "A") (STyVar "A")]]
+    )
+
+test_unknownTypeConstructorIsInvariant :: Assertion
+test_unknownTypeConstructorIsInvariant =
+  assertEqual
+    "unknown constructor variance is treated conservatively"
+    [ScalaTyParam "A" Invariant]
+    ( inferDataTyParams
+        "Wrapped"
+        ["A"]
+        [ScalaCtor "Wrapped" [STyApp "UnknownContainer" [STyVar "A"]]]
+    )

--- a/test/Name/NameEnvProps.hs
+++ b/test/Name/NameEnvProps.hs
@@ -220,5 +220,5 @@ prop_freshNumberedNames_areNeverReused =
     length outerNames === outerCount
     length innerNames === innerCount
     length (nub allGenerated) === length allGenerated
-    assert (all (\name -> name `notElem` initiallyTaken) allGenerated )
+    assert (all (`notElem` initiallyTaken) allGenerated )
     assert (null (Set.intersection (Set.fromList outerNames) (Set.fromList innerNames) ))

--- a/test/Props.hs
+++ b/test/Props.hs
@@ -12,6 +12,7 @@ import Lower.IRToScalaProps (iRToScalaProps)
 import Name.NameEnvProps (nameEnvProps)
 import Name.NamePolicyProps (namePolicyProps)
 import Render.PrintProps (printProps)
+import Lower.VarianceProps (varianceProps)
 
 main :: IO ()
 main = do
@@ -26,6 +27,7 @@ allGroups =
     , iRToScalaProps
     , termsProps
     , typesProps
+    , varianceProps
     ]
         <> namePolicyProps
 

--- a/test/Render/PrintProps.hs
+++ b/test/Render/PrintProps.hs
@@ -13,14 +13,14 @@ import Hedgehog (Gen, Group (..), Property, assert, forAll, property, success)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-import Agda.Compiler.Scala.IR.ScalaExpr (
-    ScalaExpr (..),
-    ScalaTerm (..),
-    ScalaType (..),
-    ScalaTypeScheme (..),
-    SeVar (..),
-    scalaTypeScheme,
- )
+import Agda.Compiler.Scala.IR.ScalaExpr
+  ( ScalaExpr (..)
+  , ScalaTerm (..)
+  , ScalaType (..)
+  , ScalaTypeScheme (..)
+  , SeVar (..)
+  , scalaTypeScheme
+  )
 
 import Agda.Compiler.Scala.Render.Common (escapeScalaString)
 import Agda.Compiler.Scala.Render.PrintScala2 (printScala2, printType)

--- a/test/Render/PrintScala2Test.hs
+++ b/test/Render/PrintScala2Test.hs
@@ -9,6 +9,8 @@ import Agda.Compiler.Scala.IR.ScalaExpr
     , ScalaPat (..)
     , ScalaTerm (..)
     , ScalaType (..)
+    , ScalaTyParam (..)
+    , ScalaVariance (..)
     , ScalaTypeScheme (..)
     , SeVar (..)
     , scalaTypeScheme
@@ -192,17 +194,17 @@ test_printSumPoly =
         expected
         ( printSum
             "Maybe"
-            ["A"]
+            [ ScalaTyParam "A" Covariant ]
             [ ScalaCtor "None" []
             , ScalaCtor "Just" [STyVar "A"]
             ]
         )
   where
     expected =
-        "sealed trait Maybe[A]\n"
+        "sealed trait Maybe[+A]\n"
             <> "object Maybe {\n"
             <> "  case object None extends Maybe[Nothing]\n"
-            <> "  final case class Just[A](x0: A) extends Maybe[A]\n"
+            <> "  final case class Just[+A](x0: A) extends Maybe[A]\n"
             <> "}"
 
 test_polyDef :: IO ()

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -9,6 +9,7 @@ import qualified Render.PrintScala2Test
 import qualified Render.PrintScala3Test
 import qualified ScalaBackendTest
 import qualified Compile.TypesTest
+import qualified Lower.VarianceTest
 
 main :: IO ()
 main =
@@ -25,4 +26,5 @@ tests =
         , Render.PrintScala3Test.tests
         , ScalaBackendTest.tests
         , Compile.TypesTest.tests
+        , Lower.VarianceTest.tests
         ]


### PR DESCRIPTION
Fix #26 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated Scala algebraic data types now include inferred covariance annotations where appropriate.
  * Scala 2 and Scala 3 output support improved variance handling for generic types.

* **Bug Fixes**
  * Case expressions without executable alternatives now produce a clear compilation error instead of invalid output.
  * Scala 3 example compilation now explicitly uses the Scala 3 dialect.

* **Tests**
  * Added coverage for variance inference, polymorphic rendering, and invalid case expressions.
  * Updated red-black tree examples and tests to use safer generic type behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->